### PR TITLE
Change SPARQL of stanzas use stats graph

### DIFF
--- a/genome_information_stanza/stanza.rb
+++ b/genome_information_stanza/stanza.rb
@@ -1,36 +1,35 @@
 class GenomeInformationStanza < TogoStanza::Stanza::Base
   property :genome_info_list do |tax_id|
-    results = query("http://togogenome.org/sparql", <<-SPARQL.strip_heredoc)
+    results = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       DEFINE sql:select-option "order"
       PREFIX obo: <http://purl.obolibrary.org/obo/>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-      PREFIX insdc: <http://ddbj.nig.ac.jp/ontologies/sequence#>
+      PREFIX insdc: <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
       PREFIX idtax: <http://identifiers.org/taxonomy/>
       PREFIX togo: <http://togogenome.org/stats/>
 
-      SELECT ?bioproject ?bioproject_id ?refseq_version ?refseq_link ?desc ?replicon_type ?sequence_length
-       ?gene_cnt ?trna_cnt ?rrna_cnt ?other_cnt
-      FROM <http://togogenome.org/graph/refseq/>
-      FROM <http://togogenome.org/graph/so/>
-      FROM <http://togogenome.org/graph/stats/>
+      SELECT  ?bioproject  ?bioproject_id ?refseq_version ?refseq_link  ?desc ?replicon_type ?sequence_length
+       ?gene_cnt ?rrna_cnt ?trna_cnt ?other_cnt
+      FROM <http://togogenome.org/graph/refseq>
+      FROM <http://togogenome.org/graph/so>
+      FROM <http://togogenome.org/graph/stats>
       WHERE
       {
-        ?seq rdfs:seeAlso idtax:#{tax_id} ;
-          rdfs:label ?desc ;
-          rdfs:seeAlso ?bioproject ;
-          insdc:sequence_version ?refseq_version ;
-          insdc:sequence_length ?sequence_length ;
-          rdfs:seeAlso ?refseq_link ;
-          a ?so FILTER (?so =  obo:SO_0000340 || ?so = obo:SO_0000155) .
-        ?so rdfs:label ?replicon_type .
-        ?bioproject a <http://identifiers.org/bioproject/> ;
+        idtax:#{tax_id} rdfs:seeAlso ?bioproject .
+        ?bioproject a insdc:BioProject ;
           rdfs:label ?bioproject_id .
-        ?refseq_link a <http://identifiers.org/refseq/> ;
-          togo:gene ?gene_cnt ;
+        ?refseq_link insdc:dblink ?bioproject ;
+          a insdc:Entry ;
+          insdc:sequence_version ?refseq_version ;
+          insdc:definition ?desc ;
+          insdc:sequence ?seq.
+        ?seq rdfs:subClassOf/rdfs:label ?replicon_type ;
+          insdc:sequence_length ?sequence_length .
+        ?refseq_link  togo:gene ?gene_cnt ;
           togo:rrna ?rrna_cnt ;
           togo:trna ?trna_cnt ;
           togo:other ?other_cnt .
-      }
+      } ORDER BY ?bioproject_id ?refseq_version
     SPARQL
 
     results.reverse.group_by {|hash| hash[:bioproject_id] }.map {|hash|

--- a/genome_plot_stanza/assets/genome_plot/js/plot.js
+++ b/genome_plot_stanza/assets/genome_plot/js/plot.js
@@ -141,7 +141,7 @@ function render_scatterplot(point_label, point_label_ex, x_axis_item, y_axis_ite
     .append("circle")
     .attr("class", "point")
     .attr("id", function (d) {
-      return opt.elem_id_prefix + trim_tax_prefix(d[point_label]) + "_" + trim_bioproject_prefix(d[point_label_ex])
+      return opt.elem_id_prefix + trim_tax_prefix(d[point_label])
     })
     .attr("cx", function (d) {
       return x_scale(d[x_axis_item])
@@ -353,7 +353,7 @@ function redraw_render_scatterplot() {
       .data(data)
       .attr("class", "point")
       .attr("id", function (d) {
-        return opt.elem_id_prefix + trim_tax_prefix(d.tax) + "_" + trim_bioproject_prefix(d.bioProject)
+        return opt.elem_id_prefix + trim_tax_prefix(d.tax)
       })
       .attr("fill", opt.init_point_color)
       .transition()
@@ -395,7 +395,7 @@ function redraw_render_scatterplot() {
       .data(data)
       .attr("class", "point")
       .attr("id", function (d) {
-        return opt.elem_id_prefix + trim_tax_prefix(d.tax) + "_" + trim_bioproject_prefix(d.bioProject)
+        return opt.elem_id_prefix + trim_tax_prefix(d.tax)
       })
       .attr("fill", opt.init_point_color)
       .attr("cx", function(d){
@@ -554,7 +554,7 @@ function add_tooltips_event() {
               if (opt.x_axis_items[item]) { //is axis item
                 tooltipstext += ("<tr><td>" + opt.x_axis_items[item].button_label + ": " + d[item] + "</td></tr>");
               } else {
-                tooltipstext += ("<tr><td>" + replace_tax_prefix(replace_bioproject_prefix(d[item])) + "</td></tr>");
+                tooltipstext += ("<tr><td>" + replace_tax_prefix(d[item]) + "</td></tr>");
               }
             }
           }
@@ -586,30 +586,10 @@ function trim_tax_prefix(taxid) {
 //TODO specified by opt
 Returns taxonomy id from url
 */
-function trim_bioproject_prefix(bioproject) {
-  bioproject = bioproject.replace("http://identifiers.org/bioproject/", "");
-  bioproject = bioproject.replace("http://www.ncbi.nlm.nih.gov/bioproject/", "");
-  return bioproject;
-}
-
-/*
-//TODO specified by opt
-Returns taxonomy id from url
-*/
 function replace_tax_prefix(taxid) {
   taxid = taxid.replace("http://identifiers.org/taxonomy/", "NCBI Taxonomy: ");
   taxid = taxid.replace("http://www.ncbi.nlm.nih.gov/taxonomy/", "NCBI Taxonomy: ");
   return taxid;
-}
-
-/*
-//TODO specified by opt
-Returns taxonomy id from url
-*/
-function replace_bioproject_prefix(bioproject) {
-  bioproject = bioproject.replace("http://identifiers.org/bioproject/", "NCBI BioProject: ");
-  bioproject = bioproject.replace("http://www.ncbi.nlm.nih.gov/bioproject/", "NCBI BioProject: ");
-  return bioproject;
 }
 
 /*

--- a/genome_plot_stanza/help.md
+++ b/genome_plot_stanza/help.md
@@ -7,17 +7,18 @@ Scatter plot of genomic information.
 
 (* = required)
 
-| Name                 | Description                          |
-|----------------------|--------------------------------------|
-| *data-stanza-tax-id  | Taxonomy identifier. (e.g., 103690)  |
+| Name                   | Description                          |
+|------------------------|--------------------------------------|
+| *data-stanza-refseq-id | RefSeq identifier. (e.g., NC_003272) |
+| *data-stanza-gene-id   | Gene identifier. (e.g., all1455)     |
 
 #Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/genome_plot" data-stanza-tax-id="103690"></div>
+<div data-stanza="http://togogenome.org/stanza/genome_plot" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/genome_plot" data-stanza-tax-id="103690"></div>
+<div data-stanza="/stanza/genome_plot" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
 

--- a/genome_plot_stanza/stanza.rb
+++ b/genome_plot_stanza/stanza.rb
@@ -1,6 +1,18 @@
 class GenomePlotStanza < TogoStanza::Stanza::Base
-  property :selected_taxonomy_id do |tax_id|
-    tax_id
+  property :selected_taxonomy_id do |refseq_id, gene_id|
+    tax_id =  query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
+      PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+      SELECT DISTINCT ?tax_no
+      FROM <http://togogenome.org/graph/tgup>
+      FROM <http://togogenome.org/graph/taxonomy>
+      WHERE
+      {
+       <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?tax_id .
+       ?tax_id a tax:Taxon .
+       BIND (REPLACE(STR(?tax_id), "http://identifiers.org/taxonomy/","") AS ?tax_no)
+      }
+    SPARQL
+    tax_id.first[:tax_no]
   end
 
   resource :taxonomy do
@@ -9,14 +21,14 @@ class GenomePlotStanza < TogoStanza::Stanza::Base
     genome_list = []
 
     query1 = Thread.new {
-      habitat_list = query("http://togogenome.org/sparql",<<-SPARQL.strip_heredoc)
+      habitat_list = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
         PREFIX owl: <http://www.w3.org/2002/07/owl#>
         PREFIX meo: <http://purl.jp/bio/11/meo/>
         PREFIX mccv: <http://purl.jp/bio/01/mccv#>
 
         SELECT ?tax ((sql:GROUP_DIGEST (?label, ', ', 1000, 1)) AS ?habitat)
-        FROM <http://togogenome.org/graph/gold/>
-        FROM <http://togogenome.org/graph/meo/>
+        FROM <http://togogenome.org/graph/gold>
+        FROM <http://togogenome.org/graph/meo>
         WHERE
         {
           VALUES ?p_env { meo:MEO_0000437 meo:MEO_0000440 }
@@ -31,36 +43,36 @@ class GenomePlotStanza < TogoStanza::Stanza::Base
     }
 
     query2 = Thread.new {
-      genome_list = query("http://togogenome.org/sparql",<<-SPARQL.strip_heredoc)
+      genome_list = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
         DEFINE sql:select-option "order"
         PREFIX owl: <http://www.w3.org/2002/07/owl#>
         PREFIX mccv: <http://purl.jp/bio/01/mccv#>
-        PREFIX mpo:<http://purl.jp/bio/01/mpo#>
+        PREFIX mpo: <http://purl.jp/bio/01/mpo#>
         PREFIX obo: <http://purl.obolibrary.org/obo/>
-        PREFIX insdc: <http://ddbj.nig.ac.jp/ontologies/sequence#>
-        PREFIX taxo: <http://ddbj.nig.ac.jp/ontologies/taxonomy#>
+        PREFIX insdc: <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
+        PREFIX stats: <http://togogenome.org/stats/>
+        PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+        PREFIX id_tax: <http://identifiers.org/taxonomy/>
 
         SELECT
-          ?tax ?organism_name ?bioProject ?genome_length
+          ?tax ?organism_name ?genome_length
           ((sql:GROUP_DIGEST (?cell_shape_label, ', ', 1000, 1)) AS ?cell_shape_label)
           ((sql:GROUP_DIGEST (?temp_range_label, ', ', 1000, 1)) AS ?temp_range_label)
           ((sql:GROUP_DIGEST (?oxy_req_label, ', ', 1000, 1)) AS ?oxy_req_label)
           ?opt_temp ?min_temp ?max_temp ?opt_ph ?min_ph ?max_ph
-        FROM <http://togogenome.org/graph/refseq/>
-        FROM <http://togogenome.org/graph/mpo/>
-        FROM <http://togogenome.org/graph/gold/>
-        FROM <http://togogenome.org/graph/taxonomy/>
+        FROM <http://togogenome.org/graph/refseq>
+        FROM <http://togogenome.org/graph/mpo>
+        FROM <http://togogenome.org/graph/gold>
+        FROM <http://togogenome.org/graph/stats>
+        FROM <http://togogenome.org/graph/tgtax>
+        FROM <http://togogenome.org/graph/taxonomy>
         {
-          {
-            SELECT ?tax ?bioProject (SUM(?seq_len) AS ?genome_length)
-            {
-              ?tax rdf:type <http://identifiers.org/taxonomy/> .
-              ?seq rdfs:seeAlso ?tax ;
-              rdf:type ?obo_type FILTER(?obo_type IN (obo:SO_0000340, obo:SO_0000155 )) .
-              ?seq insdc:sequence_length ?seq_len ;
-                rdfs:seeAlso ?bioProject .
-              ?bioProject rdf:type <http://identifiers.org/bioproject/> .
-            } GROUP BY ?tax  ?bioProject
+          GRAPH <http://togogenome.org/graph/tgtax> {
+            ?tax rdfs:subClassOf ?tax_scope.
+            FILTER(?tax_scope IN (id_tax:2, id_tax:2157)) #bacteria or archaea
+          }
+          GRAPH <http://togogenome.org/graph/stats> {
+            ?tax stats:sequence_length ?genome_length .
           }
           OPTIONAL { ?tax mpo:MPO_10001/rdfs:label ?cell_shape_label  FILTER (lang(?cell_shape_label) = "en") . }
           OPTIONAL { ?tax mpo:MPO_10003/rdfs:label ?temp_range_label  FILTER (lang(?temp_range_label) = "en") . }
@@ -71,28 +83,33 @@ class GenomePlotStanza < TogoStanza::Stanza::Base
           OPTIONAL { ?tax mpo:MPO_10005 ?opt_ph . }
           OPTIONAL { ?tax mpo:MPO_10006 ?min_ph . }
           OPTIONAL { ?tax mpo:MPO_10007 ?max_ph . }
-          ?tax taxo:scientificName ?organism_name
-        } GROUP BY ?tax ?organism_name ?genome_length ?bioProject  ?opt_temp ?min_temp ?max_temp ?opt_ph ?min_ph ?max_ph
+          ?tax tax:scientificName ?organism_name
+        } GROUP BY ?tax ?organism_name ?genome_length ?opt_temp ?min_temp ?max_temp ?opt_ph ?min_ph ?max_ph
       SPARQL
     }
 
-    #gene #rrna #trna
+    #gene #pseudogene #rrna #trna #ncrna
     query3 = Thread.new {
-      summary_list = query("http://togogenome.org/sparql",<<-SPARQL.strip_heredoc)
+      summary_list = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
         DEFINE sql:select-option "order"
         PREFIX togo: <http://togogenome.org/stats/>
+        PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+        PREFIX id_tax: <http://identifiers.org/taxonomy/>
 
-        SELECT ?tax ?project_id ?num_gene ?num_rrna ?num_trna
-        FROM <http://togogenome.org/graph/stats/>
-        FROM <http://togogenome.org/graph/refseq/>
+        SELECT DISTINCT ?tax ?num_gene ?num_pseudo ?num_rrna ?num_trna ?num_ncrna
         WHERE
         {
-          ?project_id a <http://identifiers.org/bioproject/> .
-          ?tax rdfs:seeAlso ?project_id .
-          ?tax a <http://identifiers.org/taxonomy/> .
-          ?project_id togo:gene ?num_gene .
-          ?project_id togo:rrna ?num_rrna .
-          ?project_id togo:trna ?num_trna.
+          GRAPH <http://togogenome.org/graph/tgtax> {
+            ?tax rdfs:subClassOf ?tax_scope.
+            FILTER(?tax_scope IN (id_tax:2, id_tax:2157)) #bacteria or archaea
+          }
+          GRAPH <http://togogenome.org/graph/stats> {
+            ?tax togo:gene ?num_gene ;
+              togo:pseudogene ?num_pseudo ;
+              togo:rrna ?num_rrna ;
+              togo:trna ?num_trna ;
+              togo:ncrna ?num_ncrna .
+          }
         }
       SPARQL
     }
@@ -108,30 +125,37 @@ class GenomePlotStanza < TogoStanza::Stanza::Base
     end
     habitat_list = nil
 
-    #gene #rrna #trna
+    #gene #pseudogene #rrna #trna #ncrna
     gene_hash ={}
+    pseudo_hash ={}
     rrna_hash ={}
     trna_hash ={}
+    ncrna_hash ={}
     summary_list.each do |entity|
-      gene_hash[entity[:tax] + "/" + entity[:project_id]] = entity[:num_gene]
-      rrna_hash[entity[:tax] + "/" + entity[:project_id]] = entity[:num_rrna]
-      trna_hash[entity[:tax] + "/" + entity[:project_id]] = entity[:num_trna]
+      gene_hash[entity[:tax]] = entity[:num_gene]
+      pseudo_hash[entity[:tax]] = entity[:num_pseudo]
+      rrna_hash[entity[:tax]] = entity[:num_rrna]
+      trna_hash[entity[:tax]] = entity[:num_trna]
+      ncrna_hash[entity[:tax]] = entity[:num_ncrna]
     end
     gene_list = nil
 
     ##merge all data
     result_list = []
     result_list = genome_list.map {|hash|
-      tax_prj_key = hash[:tax] + "/" + hash[:bioProject]
       habitat_label = habitat_hash.key?(hash[:tax]) ? habitat_hash[hash[:tax]] :'no data'
-      gene = gene_hash.key?(tax_prj_key) ? gene_hash[tax_prj_key] : '0'
-      rrna = rrna_hash.key?(tax_prj_key) ? rrna_hash[tax_prj_key] : '0'
-      trna = trna_hash.key?(tax_prj_key) ? trna_hash[tax_prj_key] : '0'
+      gene = gene_hash.key?(hash[:tax]) ? gene_hash[hash[:tax]] : '0'
+      pseudo = pseudo_hash.key?(hash[:tax]) ? pseudo_hash[hash[:tax]] : '0'
+      rrna = rrna_hash.key?(hash[:tax]) ? rrna_hash[hash[:tax]] : '0'
+      trna = trna_hash.key?(hash[:tax]) ? trna_hash[hash[:tax]] : '0'
+      ncrna = ncrna_hash.key?(hash[:tax]) ? ncrna_hash[hash[:tax]] : '0'
       hash.merge(
         habitat: habitat_label,
         num_gene: gene,
+        num_pseudo: pseudo,
         num_rrna: rrna,
         num_trna: trna,
+        num_ncrna: ncrna,
         size: hash[:genome_length]
       )
     }

--- a/genome_plot_stanza/template.hbs
+++ b/genome_plot_stanza/template.hbs
@@ -30,6 +30,10 @@
               'button_label': 'Number of genes' ,
               'axis_label': 'Number of genes'
             },
+            'num_pseudo': {
+              'button_label': 'Number of pseudo genes' ,
+              'axis_label': 'Number of pseudo genes'
+            },
             'num_rrna': {
               'button_label': 'Number of rRNAs',
               'axis_label': 'Number of rRNAs'
@@ -37,6 +41,10 @@
             'num_trna': {
               'button_label': 'Number of tRNAs',
               'axis_label': 'Number of tRNAs'
+            },
+            'num_ncrna': {
+              'button_label': 'Number of ncRNAs',
+              'axis_label': 'Number of ncRNAs'
             },
             'temperature': {
               'button_label': 'Temperature',
@@ -56,6 +64,10 @@
               'button_label': 'Number of genes',
               'axis_label': 'Number of genes'
             },
+            'num_pseudo': {
+              'button_label': 'Number of pseudo genes',
+              'axis_label': 'Number of pseudo genes'
+            },
             'num_rrna': {
               'button_label': 'Number of rRNAs',
               'axis_label': 'Number of rRNAs'
@@ -63,6 +75,10 @@
             'num_trna': {
               'button_label': 'Number of tRNAs',
               'axis_label': 'Number of tRNAs'
+            },
+            'num_ncrna': {
+              'button_label': 'Number of ncRNAs',
+              'axis_label': 'Number of ncRNAs'
             },
             'temperature': {
               'button_label': 'Temperature',
@@ -85,8 +101,8 @@
               'opt': 'opt_ph',
             },
           },
-          'tooltips_items': ['organism_name', 'tax', 'bioProject', 'size', 'num_gene', 'num_rrna',
-              'num_trna', 'temperature', 'ph'
+          'tooltips_items': ['organism_name', 'tax', 'size', 'num_gene', 'num_pseudo',
+              'num_rrna', 'num_trna', 'num_ncrna', 'temperature', 'ph'
           ],
           'no_categorize': 'no_categorize',
           'category_items': {
@@ -112,7 +128,6 @@
           'init_point_color': '#7BA67B',
           'init_selected_point_color': '#F06F60',
           'point_item': 'tax',
-          'point_item_ex': 'bioProject',
           'margin': 80,
           'width': 700,
           'height': 700,

--- a/organism_gene_number_nano_stanza/stanza.rb
+++ b/organism_gene_number_nano_stanza/stanza.rb
@@ -1,33 +1,19 @@
 class OrganismGeneNumberNanoStanza < TogoStanza::Stanza::Base
   property :genome_stats do |tax_id|
-    result = query('http://togogenome.org/sparql', <<-SPARQL.strip_heredoc).first
+    result = query('http://dev.togogenome.org/sparql-test', <<-SPARQL.strip_heredoc).first
       PREFIX tgstat:<http://togogenome.org/stats/>
       PREFIX taxid:<http://identifiers.org/taxonomy/>
 
-      SELECT DISTINCT ?project_num ?gene_num ?rrna_num ?trna_num ?ncrna_num
-      FROM <http://togogenome.org/graph/stats/>
+      SELECT DISTINCT ?gene_number ?pseudogene_number ?rrna_number ?trna_number ?ncrna_number
+      FROM <http://togogenome.org/graph/stats>
       WHERE
       {
-        taxid:#{tax_id} tgstat:bioproject ?project_num ;
-        tgstat:gene ?gene_num ;
-        tgstat:rrna ?rrna_num ;
-        tgstat:trna ?trna_num ;
-        tgstat:ncrna ?ncrna_num .
+        taxid:#{tax_id} tgstat:gene ?gene_number ;
+        tgstat:pseudogene ?pseudogene_number ;
+        tgstat:rrna ?rrna_number ;
+        tgstat:trna ?trna_number ;
+        tgstat:ncrna ?ncrna_number .
       }
     SPARQL
-
-    next if result.nil?
-
-    gene_number  = (result[:gene_num].to_f / result[:project_num].to_f).round
-    rrna_number  = (result[:rrna_num].to_f / result[:project_num].to_f).round
-    trna_number  = (result[:trna_num].to_f / result[:project_num].to_f).round
-    ncrna_number = (result[:ncrna_num].to_f / result[:project_num].to_f).round
-
-    {
-      gene_number:  gene_number,
-      rrna_number:  rrna_number,
-      trna_number:  trna_number,
-      ncrna_number: ncrna_number
-    }
   end
 end

--- a/organism_gene_number_nano_stanza/template.hbs
+++ b/organism_gene_number_nano_stanza/template.hbs
@@ -18,6 +18,9 @@
             <th class="gene">Gene</th><td>{{genome_stats.gene_number}}</td>
           </tr>
           <tr>
+            <th class="pseudo-gene">Pseudogene</th><td>{{genome_stats.pseudogene_number}}</td>
+          </tr>
+          <tr>
             <th class="t-rna">tRNA</th><td>{{genome_stats.trna_number}}</td>
           </tr>
           <tr>

--- a/protein_pfam_plot_stanza/assets/protein_pfam_plot/js/plot.js
+++ b/protein_pfam_plot_stanza/assets/protein_pfam_plot/js/plot.js
@@ -139,7 +139,7 @@ function render_scatterplot(point_label, point_label_ex, x_axis_item, y_axis_ite
     .append("circle")
     .attr("class", "point")
     .attr("id", function (d) {
-      return opt.elem_id_prefix + trim_tax_prefix(d[point_label]) + "_" + trim_bioproject_prefix(d[point_label_ex])
+      return opt.elem_id_prefix + trim_tax_prefix(d[point_label])
     })
     .attr("cx", function (d) {
       return x_scale(d[x_axis_item])
@@ -351,7 +351,7 @@ function redraw_render_scatterplot() {
       .data(data)
       .attr("class", "point")
       .attr("id", function (d) {
-        return opt.elem_id_prefix + trim_tax_prefix(d.tax) + "_" + trim_bioproject_prefix(d.bioProject)
+        return opt.elem_id_prefix + trim_tax_prefix(d.tax)
       })
       .attr("fill", opt.init_point_color)
       .transition()
@@ -393,7 +393,7 @@ function redraw_render_scatterplot() {
       .data(data)
       .attr("class", "point")
       .attr("id", function (d) {
-        return opt.elem_id_prefix + trim_tax_prefix(d.tax) + "_" + trim_bioproject_prefix(d.bioProject)
+        return opt.elem_id_prefix + trim_tax_prefix(d.tax)
       })
       .attr("fill", opt.init_point_color)
       .attr("cx", function(d){
@@ -552,7 +552,7 @@ function add_tooltips_event() {
               if (opt.x_axis_items[item]) { //is axis item
                 tooltipstext += ("<tr><td>" + opt.x_axis_items[item].button_label + ": " + d[item] + "</td></tr>");
               } else {
-                tooltipstext += ("<tr><td>" + replace_tax_prefix(replace_bioproject_prefix(d[item])) + "</td></tr>");
+                tooltipstext += ("<tr><td>" + replace_tax_prefix(d[item]) + "</td></tr>");
               }
             }
           }
@@ -584,30 +584,10 @@ function trim_tax_prefix(taxid) {
 //TODO specified by opt
 Returns taxonomy id from url
 */
-function trim_bioproject_prefix(bioproject) {
-  bioproject = bioproject.replace("http://identifiers.org/bioproject/", "");
-  bioproject = bioproject.replace("http://www.ncbi.nlm.nih.gov/bioproject/", "");
-  return bioproject;
-}
-
-/*
-//TODO specified by opt
-Returns taxonomy id from url
-*/
 function replace_tax_prefix(taxid) {
   taxid = taxid.replace("http://identifiers.org/taxonomy/", "NCBI Taxonomy: ");
   taxid = taxid.replace("http://www.ncbi.nlm.nih.gov/taxonomy/", "NCBI Taxonomy: ");
   return taxid;
-}
-
-/*
-//TODO specified by opt
-Returns taxonomy id from url
-*/
-function replace_bioproject_prefix(bioproject) {
-  bioproject = bioproject.replace("http://identifiers.org/bioproject/", "NCBI BioProject: ");
-  bioproject = bioproject.replace("http://www.ncbi.nlm.nih.gov/bioproject/", "NCBI BioProject: ");
-  return bioproject;
 }
 
 /*

--- a/protein_pfam_plot_stanza/help.md
+++ b/protein_pfam_plot_stanza/help.md
@@ -7,19 +7,19 @@ Scatter plot of pfam corresponding with genes.
 
 (* = required)
 
-| Name                 | Description                          |
-|----------------------|--------------------------------------|
-| *data-stanza-gene-id | Gene identifier. (e.g., all1455)     |
-| *data-stanza-tax-id  | Taxonomy identifier. (e.g., 103690)  |
+| Name                   | Description                          |
+|------------------------|--------------------------------------|
+| *data-stanza-refseq-id | RefSeq identifier. (e.g., NC_003272) |
+| *data-stanza-gene-id   | Gene identifier. (e.g., all1455)     |
 
 
 #Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_pfam_plot" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_pfam_plot" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_pfam_plot" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
+<div data-stanza="/stanza/protein_pfam_plot" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
 

--- a/protein_pfam_plot_stanza/stanza.rb
+++ b/protein_pfam_plot_stanza/stanza.rb
@@ -1,16 +1,16 @@
 class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
-  property :pfam_list do |tax_id,gene_id|
-    results = query("http://togogenome.org/sparql",<<-SPARQL.strip_heredoc)
+  property :pfam_list do |refseq_id, gene_id|
+    results = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
       DEFINE sql:select-option "order"
       PREFIX up: <http://purl.uniprot.org/core/>
       PREFIX taxonomy: <http://purl.uniprot.org/taxonomy/>
 
       SELECT DISTINCT (REPLACE(STR(?ref), "http://purl.uniprot.org/pfam/","") AS ?pfam_id)
-      FROM <http://togogenome.org/graph/uniprot/>
-      FROM <http://togogenome.org/graph/tgup/>
+      FROM <http://togogenome.org/graph/uniprot>
+      FROM <http://togogenome.org/graph/tgup>
       WHERE
       {
-        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> ?p ?id_upid .
+        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> ?p ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a <http://purl.uniprot.org/core/Protein> ;
           rdfs:seeAlso ?ref .
@@ -19,7 +19,6 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
         FILTER (?abbr ='Pfam').
       }
     SPARQL
-
     if results == nil || results.size == 0 then
       next nil
     end
@@ -27,7 +26,7 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
     results.each do |entity|
       pfam_hash = {}
       pfam_id = entity[:pfam_id]
-      pfam_name_list =  query("http://togogenome.org/sparql", <<-SPARQL.strip_heredoc)
+      pfam_name_list =  query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
         PREFIX pfam: <http://purl.uniprot.org/pfam/>
 
         SELECT ?label
@@ -47,32 +46,48 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
     pfam_list
   end
 
-  property :selected_tax_id do |tax_id|
-    tax_id
+  property :selected_tax_id do |refseq_id, gene_id|
+    tax_id =  query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
+      PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+      SELECT DISTINCT ?tax_no
+      FROM <http://togogenome.org/graph/tgup>
+      FROM <http://togogenome.org/graph/taxonomy>
+      WHERE
+      {
+       <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?tax_id .
+       ?tax_id a tax:Taxon .
+       BIND (REPLACE(STR(?tax_id), "http://identifiers.org/taxonomy/","") AS ?tax_no)
+      }
+    SPARQL
+    tax_id.first[:tax_no]
+  end
+
+  property :selected_refseq_id do |refseq_id|
+    refseq_id
   end
 
   property :selected_gene_id do |gene_id|
     gene_id
   end
 
-  resource :plot_data do |tax_id,gene_id|
+  resource :plot_data do |refseq_id, gene_id|
      habitat_list =[]
      summary_list = []
      genome_list = []
      pfam_list = []
      pfam_summary_list = []
 
-    pfam_list = query("http://togogenome.org/sparql",<<-SPARQL.strip_heredoc)
+    pfam_list = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
       DEFINE sql:select-option "order"
       PREFIX up: <http://purl.uniprot.org/core/>
       PREFIX taxonomy: <http://purl.uniprot.org/taxonomy/>
 
       SELECT DISTINCT (REPLACE(STR(?ref), "http://purl.uniprot.org/pfam/","") AS ?pfam_id)
-      FROM <http://togogenome.org/graph/uniprot/>
-      FROM <http://togogenome.org/graph/tgup/>
+      FROM <http://togogenome.org/graph/uniprot>
+      FROM <http://togogenome.org/graph/tgup>
       WHERE
       {
-        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> ?p ?id_upid .
+        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> ?p ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a <http://purl.uniprot.org/core/Protein> ;
           rdfs:seeAlso ?ref .
@@ -88,14 +103,14 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
     end
 
     query1 = Thread.new {
-      habitat_list = query("http://togogenome.org/sparql",<<-SPARQL.strip_heredoc)
+      habitat_list = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
         PREFIX owl: <http://www.w3.org/2002/07/owl#>
         PREFIX meo: <http://purl.jp/bio/11/meo/>
         PREFIX mccv: <http://purl.jp/bio/01/mccv#>
 
         SELECT ?tax ((sql:GROUP_DIGEST (?label, ', ', 1000, 1)) AS ?habitat)
-        FROM <http://togogenome.org/graph/gold/>
-        FROM <http://togogenome.org/graph/meo/>
+        FROM <http://togogenome.org/graph/gold>
+        FROM <http://togogenome.org/graph/meo>
         WHERE
         {
           VALUES ?p_env { meo:MEO_0000437 meo:MEO_0000440 }
@@ -110,36 +125,36 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
     }
 
     query2 = Thread.new {
-      genome_list = query("http://togogenome.org/sparql",<<-SPARQL.strip_heredoc)
+      genome_list = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
         DEFINE sql:select-option "order"
         PREFIX owl: <http://www.w3.org/2002/07/owl#>
         PREFIX mccv: <http://purl.jp/bio/01/mccv#>
-        PREFIX mpo:<http://purl.jp/bio/01/mpo#>
+        PREFIX mpo: <http://purl.jp/bio/01/mpo#>
         PREFIX obo: <http://purl.obolibrary.org/obo/>
-        PREFIX insdc: <http://ddbj.nig.ac.jp/ontologies/sequence#>
-        PREFIX taxo: <http://ddbj.nig.ac.jp/ontologies/taxonomy#>
+        PREFIX insdc: <http://ddbj.nig.ac.jp/ontologies/nucleotide/>
+        PREFIX stats: <http://togogenome.org/stats/>
+        PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+        PREFIX id_tax: <http://identifiers.org/taxonomy/>
 
         SELECT
-          ?tax ?organism_name ?bioProject ?genome_length
+          ?tax ?organism_name ?genome_length
           ((sql:GROUP_DIGEST (?cell_shape_label, ', ', 1000, 1)) AS ?cell_shape_label)
           ((sql:GROUP_DIGEST (?temp_range_label, ', ', 1000, 1)) AS ?temp_range_label)
           ((sql:GROUP_DIGEST (?oxy_req_label, ', ', 1000, 1)) AS ?oxy_req_label)
           ?opt_temp ?min_temp ?max_temp ?opt_ph ?min_ph ?max_ph
-        FROM <http://togogenome.org/graph/refseq/>
-        FROM <http://togogenome.org/graph/mpo/>
-        FROM <http://togogenome.org/graph/gold/>
-        FROM <http://togogenome.org/graph/taxonomy/>
+        FROM <http://togogenome.org/graph/refseq>
+        FROM <http://togogenome.org/graph/mpo>
+        FROM <http://togogenome.org/graph/gold>
+        FROM <http://togogenome.org/graph/stats>
+        FROM <http://togogenome.org/graph/tgtax>
+        FROM <http://togogenome.org/graph/taxonomy>
         {
-          {
-            SELECT ?tax ?bioProject (SUM(?seq_len) AS ?genome_length)
-            {
-              ?tax rdf:type <http://identifiers.org/taxonomy/> .
-              ?seq rdfs:seeAlso ?tax ;
-              rdf:type ?obo_type FILTER(?obo_type IN (obo:SO_0000340, obo:SO_0000155 )) .
-              ?seq insdc:sequence_length ?seq_len ;
-                rdfs:seeAlso ?bioProject .
-              ?bioProject rdf:type <http://identifiers.org/bioproject/> .
-            } GROUP BY ?tax  ?bioProject
+          GRAPH <http://togogenome.org/graph/tgtax> {
+            ?tax rdfs:subClassOf ?tax_scope.
+            FILTER(?tax_scope IN (id_tax:2, id_tax:2157)) #bacteria or archaea
+          }
+          GRAPH <http://togogenome.org/graph/stats> {
+            ?tax stats:sequence_length ?genome_length .
           }
           OPTIONAL { ?tax mpo:MPO_10001/rdfs:label ?cell_shape_label  FILTER (lang(?cell_shape_label) = "en") . }
           OPTIONAL { ?tax mpo:MPO_10003/rdfs:label ?temp_range_label  FILTER (lang(?temp_range_label) = "en") . }
@@ -150,28 +165,33 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
           OPTIONAL { ?tax mpo:MPO_10005 ?opt_ph . }
           OPTIONAL { ?tax mpo:MPO_10006 ?min_ph . }
           OPTIONAL { ?tax mpo:MPO_10007 ?max_ph . }
-          ?tax taxo:scientificName ?organism_name
-        } GROUP BY ?tax ?organism_name ?genome_length ?bioProject  ?opt_temp ?min_temp ?max_temp ?opt_ph ?min_ph ?max_ph
+          ?tax tax:scientificName ?organism_name
+        } GROUP BY ?tax ?organism_name ?genome_length ?opt_temp ?min_temp ?max_temp ?opt_ph ?min_ph ?max_ph
       SPARQL
     }
 
-    #gene #rrna #trna
+    #gene #pseudogene #rrna #trna #ncrna
     query3 = Thread.new {
-      summary_list = query("http://togogenome.org/sparql",<<-SPARQL.strip_heredoc)
+      summary_list = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
         DEFINE sql:select-option "order"
         PREFIX togo: <http://togogenome.org/stats/>
+        PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
+        PREFIX id_tax: <http://identifiers.org/taxonomy/>
 
-        SELECT ?tax ?project_id ?num_gene ?num_rrna ?num_trna
-        FROM <http://togogenome.org/graph/stats/>
-        FROM <http://togogenome.org/graph/refseq/>
+        SELECT ?tax ?num_gene ?num_pseudo ?num_rrna ?num_trna ?num_ncrna
         WHERE
         {
-          ?project_id a <http://identifiers.org/bioproject/> .
-          ?tax rdfs:seeAlso ?project_id .
-          ?tax a <http://identifiers.org/taxonomy/> .
-          ?project_id togo:gene ?num_gene .
-          ?project_id togo:rrna ?num_rrna .
-          ?project_id togo:trna ?num_trna.
+          GRAPH <http://togogenome.org/graph/tgtax> {
+            ?tax rdfs:subClassOf ?tax_scope.
+            FILTER(?tax_scope IN (id_tax:2, id_tax:2157)) #bacteria or archaea
+          }
+          GRAPH <http://togogenome.org/graph/stats> {
+            ?tax togo:gene ?num_gene ;
+              togo:pseudogene ?num_pseudo ;
+              togo:rrna ?num_rrna ;
+              togo:trna ?num_trna ;
+              togo:ncrna ?num_ncrna .
+          }
         }
       SPARQL
     }
@@ -187,21 +207,25 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
     end
     habitat_list = nil
 
-    #gene #rrna #trna
+    #gene #pseudogene #rrna #trna #ncrna
     gene_hash ={}
+    pseudo_hash ={}
     rrna_hash ={}
     trna_hash ={}
+    ncrna_hash ={}
     summary_list.each do |entity|
-      gene_hash[entity[:tax] + "/" + entity[:project_id]] = entity[:num_gene]
-      rrna_hash[entity[:tax] + "/" + entity[:project_id]] = entity[:num_rrna]
-      trna_hash[entity[:tax] + "/" + entity[:project_id]] = entity[:num_trna]
+      gene_hash[entity[:tax]] = entity[:num_gene]
+      pseudo_hash[entity[:tax]] = entity[:num_pseudo]
+      rrna_hash[entity[:tax]] = entity[:num_rrna]
+      trna_hash[entity[:tax]] = entity[:num_trna]
+      ncrna_hash[entity[:tax]] = entity[:num_ncrna]
     end
     summary_list = nil
 
     result_hash = {}
     pfam_list.each do |pfam_entity|
       pfam_id = pfam_entity[:pfam_id]
-      pfam_summary_list = query("http://togogenome.org/sparql",<<-SPARQL.strip_heredoc)
+      pfam_summary_list = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
         PREFIX up: <http://purl.uniprot.org/core/>
         PREFIX tax: <http://purl.uniprot.org/taxonomy/>
         PREFIX pfam: <http://purl.uniprot.org/pfam/>
@@ -210,7 +234,7 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
           (REPLACE(STR(?tax), "http://purl.uniprot.org/taxonomy/", "http://identifiers.org/taxonomy/") AS ?tax_id)
           ((SUM(?hits) AS ?num_pfam))
           (COUNT(DISTINCT(?prot_id)) AS ?num_pfam_protein)
-        FROM <http://togogenome.org/graph/uniprot/>
+        FROM <http://togogenome.org/graph/uniprot>
         WHERE
         {
           ?prot_id up:organism ?tax .
@@ -232,18 +256,21 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
       ##merge all data
       tax_list = []
       tax_list = genome_list.map {|hash|
-        tax_prj_key = hash[:tax] + "/" + hash[:bioProject]
         habitat_label = habitat_hash.key?(hash[:tax]) ? habitat_hash[hash[:tax]] :'no data'
-        gene = gene_hash.key?(tax_prj_key) ? gene_hash[tax_prj_key] : '0'
-        rrna = rrna_hash.key?(tax_prj_key) ? rrna_hash[tax_prj_key] : '0'
-        trna = trna_hash.key?(tax_prj_key) ? trna_hash[tax_prj_key] : '0'
+        gene = gene_hash.key?(hash[:tax]) ? gene_hash[hash[:tax]] : '0'
+        pseudo = pseudo_hash.key?(hash[:tax]) ? pseudo_hash[hash[:tax]] : '0'
+        rrna = rrna_hash.key?(hash[:tax]) ? rrna_hash[hash[:tax]] : '0'
+        trna = trna_hash.key?(hash[:tax]) ? trna_hash[hash[:tax]] : '0'
+        ncrna = ncrna_hash.key?(hash[:tax]) ? ncrna_hash[hash[:tax]] : '0'
         pfam = pfam_hash.key?(hash[:tax]) ? pfam_hash[hash[:tax]] : '0'
         pfam_protein = pfam_protein_hash.key?(hash[:tax]) ? pfam_protein_hash[hash[:tax]] : '0'
         hash.merge(
           habitat: habitat_label,
           num_gene: gene,
+          num_pseudo: pseudo,
           num_rrna: rrna,
           num_trna: trna,
+          num_ncrna: ncrna,
           num_pfam: pfam,
           num_pfam_protein: pfam_protein,
           size: hash[:genome_length]

--- a/protein_pfam_plot_stanza/template.hbs
+++ b/protein_pfam_plot_stanza/template.hbs
@@ -31,6 +31,10 @@
               'button_label': 'Number of genes' ,
               'axis_label': 'Number of genes'
             },
+            'num_pseudo': {
+              'button_label': 'Number of pseudo genes' ,
+              'axis_label': 'Number of pseudo genes'
+            },
             'num_rrna': {
               'button_label': 'Number of rRNAs',
               'axis_label': 'Number of rRNAs'
@@ -38,6 +42,10 @@
             'num_trna': {
               'button_label': 'Number of tRNAs',
               'axis_label': 'Number of tRNAs'
+            },
+            'num_ncrna': {
+              'button_label': 'Number of ncRNAs',
+              'axis_label': 'Number of ncRNAs'
             },
             'num_pfam': {
               'button_label': 'Number of Pfam domains',
@@ -65,12 +73,20 @@
               'button_label': 'Number of genes' ,
               'axis_label': 'Number of genes'
             },
+            'num_pseudo': {
+              'button_label': 'Number of pseudo genes' ,
+              'axis_label': 'Number of pseudo genes'
+            },
             'num_rrna': {
               'button_label': 'Number of rRNAs',
               'axis_label': 'Number of rRNAs'
             },
             'num_trna': {
               'button_label': 'Number of tRNAs',
+              'axis_label': 'Number of tRNAs'
+            },
+            'num_ncrna': {
+              'button_label': 'Number of ncRNAs',
               'axis_label': 'Number of tRNAs'
             },
             'num_pfam': {
@@ -103,8 +119,8 @@
               'opt': 'opt_ph',
             },
           },
-          'tooltips_items': ['organism_name', 'tax','bioProject', 'size', 'num_gene', 'num_rrna',
-              'num_trna', 'num_pfam', 'num_pfam_protein', 'temperature', 'ph'
+          'tooltips_items': ['organism_name', 'tax', 'size', 'num_gene', 'num_pseudo',
+              'num_rrna', 'num_trna', 'num_ncrna', 'num_pfam', 'num_pfam_protein', 'temperature', 'ph'
           ],
           'no_categorize': 'no_categorize',
           'category_items': {
@@ -130,7 +146,6 @@
           'init_point_color': '#7BA67B',
           'init_selected_point_color': '#F06F60',
           'point_item': 'tax',
-          'point_item_ex': 'bioProject',
           'margin': 80,
           'width': 700,
           'height': 700,
@@ -147,7 +162,7 @@
           'pfam_list': [{{#if pfam_list}}{{#each pfam_list}}{"key":"{{id}}","value":"{{name}}"},{{/each}}{{/if}}],
         }
 
-        d3.json('./protein_pfam_plot/resources/plot_data?tax_id={{selected_tax_id}}&gene_id={{selected_gene_id}}', function(data) {
+        d3.json('./protein_pfam_plot/resources/plot_data?refseq_id={{selected_refseq_id}}&gene_id={{selected_gene_id}}', function(data) {
           //console.log(JSON.stringify(data,null," "));
           if(data.plot_data == null) {
             $("#vis").text("No data");


### PR DESCRIPTION
*真核生物を含む新しいRefSeqデータ構造に対応
*グラフ名の修正
*plot系グラフでは[tax+bioproject]をキーとしていたがbioprojectに多数のTaxIDが含まれているケースがあるため、[tax]だけに変更
*tgupの引数変更(taxid&locus_tag => refseq&gene_name)に対応