### PR TITLE
pseudogene_number を出さないようにした

### DIFF
--- a/organism_gene_number_nano_stanza/stanza.rb
+++ b/organism_gene_number_nano_stanza/stanza.rb
@@ -4,12 +4,11 @@ class OrganismGeneNumberNanoStanza < TogoStanza::Stanza::Base
       PREFIX tgstat:<http://togogenome.org/stats/>
       PREFIX taxid:<http://identifiers.org/taxonomy/>
 
-      SELECT DISTINCT ?gene_number ?pseudogene_number ?rrna_number ?trna_number ?ncrna_number
+      SELECT DISTINCT ?gene_number ?rrna_number ?trna_number ?ncrna_number
       FROM <http://togogenome.org/graph/stats>
       WHERE
       {
         taxid:#{tax_id} tgstat:gene ?gene_number ;
-        tgstat:pseudogene ?pseudogene_number ;
         tgstat:rrna ?rrna_number ;
         tgstat:trna ?trna_number ;
         tgstat:ncrna ?ncrna_number .

--- a/organism_gene_number_nano_stanza/template.hbs
+++ b/organism_gene_number_nano_stanza/template.hbs
@@ -18,9 +18,6 @@
             <th class="gene">Gene</th><td>{{genome_stats.gene_number}}</td>
           </tr>
           <tr>
-            <th class="pseudo-gene">Pseudogene</th><td>{{genome_stats.pseudogene_number}}</td>
-          </tr>
-          <tr>
             <th class="t-rna">tRNA</th><td>{{genome_stats.trna_number}}</td>
           </tr>
           <tr>


### PR DESCRIPTION
- ナノスタンザに表示する情報量が増えるため出さない方が良さそう
- ここに表示している内容をどうするかは今後の検討課題とする