### PR TITLE
coordinated the jbrowse domain with endpoint

### DIFF
--- a/genome_jbrowse_stanza/template.hbs
+++ b/genome_jbrowse_stanza/template.hbs
@@ -37,7 +37,7 @@
   </head>
   <body onload="init({{select_tax_id}})">
     <div id="jbrowse">
-      <iframe src="http://ep.dbcls.jp/jbrowse/?data={{select_tax_id}}&loc={{display_range.ref}}%3A{{display_range.disp_start}}..{{display_range.disp_end}}&tracks=cds%2Ctrna%2Crrna&highlight=" frameborder="0" style="width: 100%;" id="jbrowse-frame"></iframe>
+      <iframe src="http://togogenome.org/jbrowse/?data={{select_tax_id}}&loc={{display_range.ref}}%3A{{display_range.disp_start}}..{{display_range.disp_end}}&tracks=cds%2Ctrna%2Crrna&highlight=" frameborder="0" style="width: 100%;" id="jbrowse-frame"></iframe>
     </div>
   </body>
 </html>

--- a/organism_jbrowse_stanza/template.hbs
+++ b/organism_jbrowse_stanza/template.hbs
@@ -38,7 +38,7 @@
 
   <body onload="init({{sequence_version.tax_id}})">
     <div id="jbrowse">
-      <iframe src="http://ep.dbcls.jp/jbrowse/?data={{sequence_version.tax_id}}&tracks=cds%2Ctrna%2Crrna&highlight=&loc={{sequence_version.ref}}%3A{{sequence_version.display_start_pos}}..{{sequence_version.display_end_pos}}" frameborder="0" style="width: 100%;" id="jbrowse-frame"></iframe>
+      <iframe src="http://togogenome.org/jbrowse/?data={{sequence_version.tax_id}}&tracks=cds%2Ctrna%2Crrna&highlight=&loc={{sequence_version.ref}}%3A{{sequence_version.display_start_pos}}..{{sequence_version.display_end_pos}}" frameborder="0" style="width: 100%;" id="jbrowse-frame"></iframe>
     </div>
   </body>
 </html>


### PR DESCRIPTION
エンドポイントのURL変更に伴い、JBrowseからのSPARQLクエリでクロスドメイン問題したため、JBrowseのドメインも修正。