### PR TITLE
Changed the parameter of gene stanzas from refseq_id to tax_id

### DIFF
--- a/gene_attributes_stanza/stanza.rb
+++ b/gene_attributes_stanza/stanza.rb
@@ -17,9 +17,14 @@ class GeneAttributesStanza < TogoStanza::Stanza::Base
         ?strand ?insdc_location
       WHERE
       {
-        GRAPH <http://togogenome.org/graph/tgup>
         {
-          <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+          SELECT ?feature_uri
+          {
+            GRAPH <http://togogenome.org/graph/tgup>
+            {
+              <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+            }
+          } ORDER BY ?feature_uri LIMIT 1
         }
         GRAPH <http://togogenome.org/graph/refseq>
         {

--- a/gene_length_nano_stanza/help.md
+++ b/gene_length_nano_stanza/help.md
@@ -9,15 +9,15 @@ NanoStanza for showing gene length
 
 | Name                    | Description                          |
 |-------------------------|--------------------------------------|
-| *data-stanza-refseq-id  | RefSeq identifier. (e.g., NC_003272) |
+| *data-stanza-tax-id     | Taxonomy identifier. (e.g., 103690)  |
 | *data-stanza-gene-id    | Gene identifier. (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/gene_length_nano" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="http://togogenome.org/stanza/gene_length_nano" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/gene_length_nano" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="/stanza/gene_length_nano" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/gene_length_nano_stanza/stanza.rb
+++ b/gene_length_nano_stanza/stanza.rb
@@ -3,7 +3,7 @@ class GeneLengthNanoStanza < TogoStanza::Stanza::Base
     "Gene length"
   end
 
-  property :result do |refseq_id, gene_id|
+  property :result do |tax_id, gene_id|
     query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc).first
       PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>
@@ -12,9 +12,14 @@ class GeneLengthNanoStanza < TogoStanza::Stanza::Base
       PREFIX insdc:  <http://ddbj.nig.ac.jp/ontologies/sequence#>
       SELECT (ABS(?gene_end - ?gene_begin) + 1 AS ?gene_length)
       WHERE {
-        GRAPH <http://togogenome.org/graph/tgup>
         {
-          <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+          SELECT ?feature_uri
+          {
+            GRAPH <http://togogenome.org/graph/tgup>
+            {
+              <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+            }
+          } ORDER BY ?feature_uri LIMIT 1
         }
         GRAPH <http://togogenome.org/graph/refseq>
         {

--- a/genome_jbrowse_stanza/help.md
+++ b/genome_jbrowse_stanza/help.md
@@ -9,15 +9,15 @@ Schematic view of the structure and surroundings of a gene
 
 | Name                    | Description                          |
 |-------------------------|--------------------------------------|
-| *data-stanza-refseq-id  | RefSeq identifier. (e.g., NC_003272) |
+| *data-stanza-tax-id     | Taxonomy identifier. (e.g., 103690)  |
 | *data-stanza-gene-id    | Gene identifier. (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/genome_jbrowse" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="http://togogenome.org/stanza/genome_jbrowse" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/genome_jbrowse" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="/stanza/genome_jbrowse" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/genome_jbrowse_stanza/stanza.rb
+++ b/genome_jbrowse_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class GenomeJbrowseStanza < TogoStanza::Stanza::Base
-  property :select_tax_id do |refseq_id, gene_id|
+  property :select_tax_id do |tax_id, gene_id|
     results = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       DEFINE sql:select-option "order"
       PREFIX obo: <http://purl.obolibrary.org/obo/>
@@ -7,9 +7,14 @@ class GenomeJbrowseStanza < TogoStanza::Stanza::Base
       SELECT DISTINCT (REPLACE(STR(?taxonomy),"http://identifiers.org/taxonomy/","") AS ?tax_id)
       WHERE
       {
-        GRAPH <http://togogenome.org/graph/tgup>
         {
-          <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+          SELECT ?feature_uri
+          {
+            GRAPH <http://togogenome.org/graph/tgup>
+            {
+              <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+            }
+          } ORDER BY ?feature_uri LIMIT 1
         }
         GRAPH <http://togogenome.org/graph/refseq>
         {
@@ -21,7 +26,7 @@ class GenomeJbrowseStanza < TogoStanza::Stanza::Base
     (results.length == 1) ? results.first[:tax_id] : nil
   end
 
-  property :display_range do |refseq_id, gene_id|
+  property :display_range do |tax_id, gene_id|
     result = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc).first
       DEFINE sql:select-option "order"
       PREFIX obo: <http://purl.obolibrary.org/obo/>
@@ -31,9 +36,14 @@ class GenomeJbrowseStanza < TogoStanza::Stanza::Base
       SELECT ?seq_label ?start ?end ?seq_length
       WHERE
       {
-        GRAPH <http://togogenome.org/graph/tgup>
         {
-          <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+          SELECT ?feature_uri
+          {
+            GRAPH <http://togogenome.org/graph/tgup>
+            {
+              <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+            }
+          } ORDER BY ?feature_uri LIMIT 1
         }
         GRAPH <http://togogenome.org/graph/refseq>
         {

--- a/genome_plot_stanza/help.md
+++ b/genome_plot_stanza/help.md
@@ -9,16 +9,16 @@ Scatter plot of genomic information.
 
 | Name                   | Description                          |
 |------------------------|--------------------------------------|
-| *data-stanza-refseq-id | RefSeq identifier. (e.g., NC_003272) |
+| *data-stanza-tax-id    | Taxonomy identifier. (e.g., 103690)  |
 | *data-stanza-gene-id   | Gene identifier. (e.g., all1455)     |
 
 #Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/genome_plot" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="http://togogenome.org/stanza/genome_plot" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/genome_plot" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="/stanza/genome_plot" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 

--- a/genome_plot_stanza/stanza.rb
+++ b/genome_plot_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class GenomePlotStanza < TogoStanza::Stanza::Base
-  property :selected_taxonomy_id do |refseq_id, gene_id|
+  property :selected_taxonomy_id do |tax_id, gene_id|
     tax_id =  query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
       SELECT DISTINCT ?tax_no
@@ -7,9 +7,16 @@ class GenomePlotStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/taxonomy>
       WHERE
       {
-       <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?tax_id .
-       ?tax_id a tax:Taxon .
-       BIND (REPLACE(STR(?tax_id), "http://identifiers.org/taxonomy/","") AS ?tax_no)
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?tax_id .
+        ?tax_id a tax:Taxon .
+        BIND (REPLACE(STR(?tax_id), "http://identifiers.org/taxonomy/","") AS ?tax_no)
       }
     SPARQL
 

--- a/nucleotide_sequence_stanza/help.md
+++ b/nucleotide_sequence_stanza/help.md
@@ -9,15 +9,15 @@ Nucleotide sequences of the specified gene ID.
 
 | Name                    | Description                          |
 |-------------------------|--------------------------------------|
-| *data-stanza-refseq-id  | RefSeq identifier. (e.g., NC_003272) |
+| *data-stanza-tax-id     | Taxonomy identifier. (e.g., 103690)  |
 | *data-stanza-gene-id    | Gene identifier. (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/nucleotide_sequence" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="http://togogenome.org/stanza/nucleotide_sequence" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/nucleotide_sequence" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="/stanza/nucleotide_sequence" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/nucleotide_sequence_stanza/stanza.rb
+++ b/nucleotide_sequence_stanza/stanza.rb
@@ -2,7 +2,7 @@ require 'net/http'
 require 'uri'
 
 class NucleotideSequenceStanza < TogoStanza::Stanza::Base
-  property :nucleotide_sequences do |refseq_id, gene_id|
+  property :nucleotide_sequences do |tax_id, gene_id|
     results = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       DEFINE sql:select-option "order"
       PREFIX obo:    <http://purl.obolibrary.org/obo/>
@@ -12,9 +12,14 @@ class NucleotideSequenceStanza < TogoStanza::Stanza::Base
       SELECT DISTINCT ?nuc_seq_pos
       WHERE
       {
-        GRAPH <http://togogenome.org/graph/tgup>
         {
-          <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+          SELECT ?feature_uri
+          {
+            GRAPH <http://togogenome.org/graph/tgup>
+            {
+              <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?feature_uri .
+            }
+          } ORDER BY ?feature_uri LIMIT 1
         }
         GRAPH <http://togogenome.org/graph/refseq>
         {

--- a/protein_3d_structure_nano_stanza/help.md
+++ b/protein_3d_structure_nano_stanza/help.md
@@ -9,15 +9,15 @@ NanoStanza: Display an schematic mage of protein 3D structure of specifined gene
 
 | Name                   | Description                |
 |------------------------|----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g. NC_003272) |
+| *data-stanza-tax-id    | Taxonomy ID (e.g. 103690)  |
 | *data-stanza-gene-id   | Gene ID (e.g. alr3421)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_3d_structure" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="alr3421"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_3d_structure" data-stanza-tax-id="103690" data-stanza-gene-id="alr3421"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_3d_structure_nano" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="alr3421"></div>
+<div data-stanza="/stanza/protein_3d_structure_nano" data-stanza-tax-id="103690" data-stanza-gene-id="alr3421"></div>

--- a/protein_3d_structure_nano_stanza/stanza.rb
+++ b/protein_3d_structure_nano_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class Protein3dStructureNanoStanza < TogoStanza::Stanza::Base
-  property :pdb do |refseq_id, gene_id|
+  property :pdb do |tax_id, gene_id|
     result = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc).first
       PREFIX up: <http://purl.uniprot.org/core/>
 
@@ -7,7 +7,14 @@ class Protein3dStructureNanoStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/uniprot>
       FROM <http://togogenome.org/graph/tgup>
       WHERE {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a up:Protein .
         ?attr rdf:subject ?protein .

--- a/protein_attributes_stanza/help.md
+++ b/protein_attributes_stanza/help.md
@@ -9,15 +9,15 @@ See also: http://www.uniprot.org/manual/?query=category%3Aprotein_attributes
 
 | Name                   | Description                 |
 |------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_000911) |
-| *data-stanza-gene-id   | Gene ID (e.g., slr1311)     |
+| *data-stanza-tax-id    | Taxonomy ID (e.g., 103690)  |
+| *data-stanza-gene-id   | Gene ID (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_attributes" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_attributes" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_attributes" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="/stanza/protein_attributes" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_attributes_stanza/stanza.rb
+++ b/protein_attributes_stanza/stanza.rb
@@ -1,11 +1,18 @@
 class ProteinAttributesStanza < TogoStanza::Stanza::Base
-  property :attributes do |refseq_id, gene_id|
+  property :attributes do |tax_id, gene_id|
     protein_attributes = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       PREFIX up: <http://purl.uniprot.org/core/>
 
       SELECT DISTINCT ?sequence ?fragment ?precursor ?existence_label
       WHERE {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a up:Protein ;
                  up:sequence ?seq .

--- a/protein_cross_references_stanza/help.md
+++ b/protein_cross_references_stanza/help.md
@@ -7,17 +7,18 @@ See also: http://www.uniprot.org/manual/?query=category%3Across_references
 
 (* = required)
 
-| Name                   | Description                 |
-|------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_000911) |
-| *data-stanza-gene-id   | Gene ID (e.g., slr1311)     |
+| Name                   | Description                |
+|------------------------|----------------------------|
+| *data-stanza-tax-id    | Taxonomy ID (e.g. 103690)  |
+| *data-stanza-gene-id   | Gene ID (e.g. all1455)     |
+
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_cross_references" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_cross_references" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_cross_references" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="/stanza/protein_cross_references" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_cross_references_stanza/stanza.rb
+++ b/protein_cross_references_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class ProteinCrossReferencesStanza < TogoStanza::Stanza::Base
-  property :references do |refseq_id, gene_id|
+  property :references do |tax_id, gene_id|
     references = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       PREFIX up: <http://purl.uniprot.org/core/>
 
@@ -7,11 +7,17 @@ class ProteinCrossReferencesStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/uniprot>
       FROM <http://togogenome.org/graph/tgup>
       WHERE {
-
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a up:Protein ;
-                 rdfs:seeAlso    ?ref .
+          rdfs:seeAlso    ?ref .
         ?ref      up:database     ?database .
         ?database up:category     ?category ;
                   up:abbreviation ?abbr ;

--- a/protein_ec_number_nano_stanza/help.md
+++ b/protein_ec_number_nano_stanza/help.md
@@ -9,15 +9,15 @@ NanoStanza: Display an EC number of an enzyme coded by a specified gene
 
 | Name                   | Description                |
 |------------------------|----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g. NC_017168) |
-| *data-stanza-gene-id   | Gene ID (e.g. A1122_00435) |
+| *data-stanza-tax-id    | Taxonomy ID (e.g. 103690)  |
+| *data-stanza-gene-id   | Gene ID (e.g. all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_ec_number_nano" data-stanza-refseq-id="NC_017168" data-stanza-gene-id="A1122_00435"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_ec_number_nano" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_ec_number_nano" data-stanza-refseq-id="NC_017168" data-stanza-gene-id="A1122_00435"></div>
+<div data-stanza="/stanza/protein_ec_number_nano" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_ec_number_nano_stanza/stanza.rb
+++ b/protein_ec_number_nano_stanza/stanza.rb
@@ -1,12 +1,19 @@
 class ProteinEcNumberNanoStanza < TogoStanza::Stanza::Base
-  property :feature do |refseq_id, gene_id|
+  property :feature do |tax_id, gene_id|
     query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc).first
       PREFIX up: <http://purl.uniprot.org/core/>
       SELECT ?ec_number
       FROM <http://togogenome.org/graph/uniprot>
       FROM <http://togogenome.org/graph/tgup>
       WHERE {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a up:Protein .
         ?protein up:recommendedName ?recommended_name_node .

--- a/protein_general_annotation_stanza/help.md
+++ b/protein_general_annotation_stanza/help.md
@@ -9,15 +9,15 @@ See also: http://www.uniprot.org/manual/?query=category%3Ageneral_annotation
 
 | Name                   | Description                 |
 |------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_000911) |
-| *data-stanza-gene-id   | Gene ID (e.g., slr1311)     |
+| *data-stanza-tax-id    | Taxonomy ID (e.g., 103690)  |
+| *data-stanza-gene-id   | Gene ID (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_general_annotation" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_general_annotation" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_general_annotation" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="/stanza/protein_general_annotation" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_general_annotation_stanza/stanza.rb
+++ b/protein_general_annotation_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class ProteinGeneralAnnotationStanza < TogoStanza::Stanza::Base
-  property :general_annotations do |refseq_id, gene_id|
+  property :general_annotations do |tax_id, gene_id|
 
     result = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
     PREFIX up: <http://purl.uniprot.org/core/>
@@ -8,7 +8,14 @@ class ProteinGeneralAnnotationStanza < TogoStanza::Stanza::Base
     FROM <http://togogenome.org/graph/uniprot>
     FROM <http://togogenome.org/graph/tgup>
     WHERE {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a up:Protein ;
                  up:annotation ?annotation .

--- a/protein_names_stanza/help.md
+++ b/protein_names_stanza/help.md
@@ -9,15 +9,15 @@ See also: http://www.uniprot.org/manual/?query=category%3Anames_origin
 
 | Name                   | Description                 |
 |------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_000911) |
-| *data-stanza-gene-id   | Gene ID (e.g., slr1311)     |
+| *data-stanza-tax-id    | Taxonomy ID (e.g., 103690)  |
+| *data-stanza-gene-id   | Gene ID (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_names" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_names" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_names" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="/stanza/protein_names" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_ontologies_stanza/help.md
+++ b/protein_ontologies_stanza/help.md
@@ -9,15 +9,15 @@ See also: http://www.uniprot.org/manual/?query=category%3Aontologies
 
 | Name                   | Description                 |
 |------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_003272) |
+| *data-stanza-tax-id    | Taxonomy ID (e.g., 103690)  |
 | *data-stanza-gene-id   | Gene ID (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_ontologies" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_ontologies" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_ontologies" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="/stanza/protein_ontologies" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_ontologies_stanza/stanza.rb
+++ b/protein_ontologies_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class ProteinOntologiesStanza < TogoStanza::Stanza::Base
-  property :keywords do |refseq_id, gene_id|
+  property :keywords do |tax_id, gene_id|
     keywords = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       DEFINE sql:select-option "order"
       PREFIX up: <http://purl.uniprot.org/core/>
@@ -10,7 +10,14 @@ class ProteinOntologiesStanza < TogoStanza::Stanza::Base
         FROM <http://togogenome.org/graph/uniprot>
         FROM <http://togogenome.org/graph/tgup>
         WHERE {
-          <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+          {
+            SELECT ?gene
+            {
+              <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+            } ORDER BY ?gene LIMIT 1
+          }
+          <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+            rdfs:seeAlso ?id_upid .
           ?id_upid rdfs:seeAlso ?protein .
           ?protein a up:Protein ;
                    up:classifiedWith ?concept .
@@ -32,63 +39,37 @@ class ProteinOntologiesStanza < TogoStanza::Stanza::Base
     }
   end
 
-  property :gene_ontlogies do |refseq_id, gene_id|
-
-    # slr1311 の時...
-
-    # UniProt の go の URI と UniProt のエントリの関係
-    ## [{:concept=>"http://purl.uniprot.org/go/0009635"},
-    ##  {:concept=>"http://purl.uniprot.org/go/0009772"},
-    ##  ... ]
-    up_go_uris = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
-      PREFIX up: <http://purl.uniprot.org/core/>
-      PREFIX taxonomy: <http://purl.uniprot.org/taxonomy/>
-
-      SELECT DISTINCT ?concept
-      FROM <http://togogenome.org/graph/uniprot>
-      FROM <http://togogenome.org/graph/tgup>
-      WHERE {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
-        ?id_upid rdfs:seeAlso ?protein .
-        ?protein a up:Protein ;
-                 up:classifiedWith ?concept .
-        ?concept rdf:type up:Concept .
-        FILTER contains(str(?concept), 'go') .
-      }
-    SPARQL
-
-    next if up_go_uris.empty?
-
-    # OBO の go の URI を UniProt の go の URI へ変換
-    obo_go_uris = up_go_uris.map {|e| {obo_go_uri: e[:concept].gsub("http://purl.uniprot.org/go/", "http://purl.obolibrary.org/obo/GO_")} }
-
-    next if obo_go_uris.empty?
-
-    # OBO の go の階層とラベル
-    # "<http://purl.obolibrary.org/obo/GO_0009635>, <http://purl.obolibrary.org/obo/GO_0009772>, ..."
-    obo_go_uri_values = obo_go_uris.flat_map {|uri|
-      "<#{uri[:obo_go_uri]}>"
-    }.join(', ')
-
+  property :gene_ontlogies do |tax_id, gene_id|
     ## [{:root_name=>"biological_process", :name=>"response to herbicide"},
     ##  {:root_name=>"biological_process", :name=>"photosynthetic electron transport in photosystem II"},
     ##  {:root_name=>"molecular_function", :name=>"oxidoreductase activity"},
     ##  ...]
     gene_ontlogies = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
-      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX up: <http://purl.uniprot.org/core/>
+      PREFIX taxonomy: <http://purl.uniprot.org/taxonomy/>
 
       SELECT DISTINCT ?name ?root_name ?obo_go_uri
+      FROM <http://togogenome.org/graph/uniprot>
+      FROM <http://togogenome.org/graph/tgup>
       FROM <http://togogenome.org/graph/go>
       WHERE {
-        ?obo_go_uri rdfs:label ?name .
-        # comment は無い?
-        # cf) http://lod.dbcls.jp/openrdf-workbench5l/repositories/go/explore?resource=obo%3AGO_0009635
-        #?obo_go_uri rdfs:comment ?comment .
-
-        ?obo_go_uri rdfs:subClassOf* ?parents .
-        ?parents rdfs:label ?root_name .
-        FILTER (str(?root_name) IN ('biological_process', 'cellular_component', 'molecular_function')) .
-        FILTER (?obo_go_uri in (#{obo_go_uri_values})) .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
+        ?id_upid rdfs:seeAlso ?protein .
+        ?protein a up:Protein ;
+                 up:classifiedWith ?obo_go_uri .
+        GRAPH <http://togogenome.org/graph/go> {
+          ?obo_go_uri rdfs:label ?name .
+          ?obo_go_uri rdfs:subClassOf* ?parents .
+          ?parents rdfs:label ?root_name .
+          FILTER (str(?root_name) IN ('biological_process', 'cellular_component', 'molecular_function')) . 
+        }
       }
     SPARQL
 

--- a/protein_orthologs_stanza/help.md
+++ b/protein_orthologs_stanza/help.md
@@ -9,15 +9,15 @@ Show members of ortholog group
 
 | Name                   | Description                 |
 |------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_003272) |
+| *data-stanza-tax-id    | Taxonomy ID (e.g., 103690)  |
 | *data-stanza-gene_id   | Gene ID (e.g., alr3431)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_orthologs" data-stanza-refseq-id="NC_003272" data-stanza-gene_id="alr3431"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_orthologs" data-stanza-tax-id="103690" data-stanza-gene_id="alr3431"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_orthologs" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="alr3431"></div>
+<div data-stanza="/stanza/protein_orthologs" data-stanza-tax-id="103690" data-stanza-gene-id="alr3431"></div>

--- a/protein_pfam_plot_stanza/help.md
+++ b/protein_pfam_plot_stanza/help.md
@@ -9,17 +9,17 @@ Scatter plot of pfam corresponding with genes.
 
 | Name                   | Description                          |
 |------------------------|--------------------------------------|
-| *data-stanza-refseq-id | RefSeq identifier. (e.g., NC_003272) |
-| *data-stanza-gene-id   | Gene identifier. (e.g., all1455)     |
+| *data-stanza-tax-id    | Taxonomy identifier. (e.g., 103690)  |
+| *data-stanza-gene-id   | Gene identifier. (e.g., all4233)     |
 
 
 #Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_pfam_plot" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_pfam_plot" data-stanza-tax-id="103690" data-stanza-gene-id="all4233"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_pfam_plot" data-stanza-refseq-id="NC_003272" data-stanza-gene-id="all1455"></div>
+<div data-stanza="/stanza/protein_pfam_plot" data-stanza-tax-id="103690" data-stanza-gene-id="all4233"></div>
 

--- a/protein_pfam_plot_stanza/stanza.rb
+++ b/protein_pfam_plot_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
-  property :pfam_list do |refseq_id, gene_id|
+  property :pfam_list do |tax_id, gene_id|
     results = query("http://dev.togogenome.org/sparql-test",<<-SPARQL.strip_heredoc)
       DEFINE sql:select-option "order"
       PREFIX up: <http://purl.uniprot.org/core/>
@@ -10,7 +10,14 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/tgup>
       WHERE
       {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> ?p ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a <http://purl.uniprot.org/core/Protein> ;
           rdfs:seeAlso ?ref .
@@ -46,7 +53,7 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
     pfam_list
   end
 
-  property :selected_tax_id do |refseq_id, gene_id|
+  property :selected_tax_id do |tax_id, gene_id|
     tax_id =  query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>
       SELECT DISTINCT ?tax_no
@@ -54,23 +61,30 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/taxonomy>
       WHERE
       {
-       <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?tax_id .
-       ?tax_id a tax:Taxon .
-       BIND (REPLACE(STR(?tax_id), "http://identifiers.org/taxonomy/","") AS ?tax_no)
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?tax_id .
+        ?tax_id a tax:Taxon .
+        BIND (REPLACE(STR(?tax_id), "http://identifiers.org/taxonomy/","") AS ?tax_no)
       }
     SPARQL
     tax_id.first[:tax_no]
   end
 
-  property :selected_refseq_id do |refseq_id|
-    refseq_id
+  property :selected_tax_id do |tax_id|
+    tax_id
   end
 
   property :selected_gene_id do |gene_id|
     gene_id
   end
 
-  resource :plot_data do |refseq_id, gene_id|
+  resource :plot_data do |tax_id, gene_id|
      habitat_list =[]
      summary_list = []
      genome_list = []
@@ -87,7 +101,14 @@ class ProteinPfamPlotStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/tgup>
       WHERE
       {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> ?p ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a <http://purl.uniprot.org/core/Protein> ;
           rdfs:seeAlso ?ref .

--- a/protein_pfam_plot_stanza/template.hbs
+++ b/protein_pfam_plot_stanza/template.hbs
@@ -162,7 +162,7 @@
           'pfam_list': [{{#if pfam_list}}{{#each pfam_list}}{"key":"{{id}}","value":"{{name}}"},{{/each}}{{/if}}],
         }
 
-        d3.json('./protein_pfam_plot/resources/plot_data?refseq_id={{selected_refseq_id}}&gene_id={{selected_gene_id}}', function(data) {
+        d3.json('./protein_pfam_plot/resources/plot_data?tax_id={{selected_tax_id}}&gene_id={{selected_gene_id}}', function(data) {
           //console.log(JSON.stringify(data,null," "));
           if(data.plot_data == null) {
             $("#vis").text("No data");

--- a/protein_references_stanza/help.md
+++ b/protein_references_stanza/help.md
@@ -9,15 +9,15 @@ See also: http://www.uniprot.org/manual/?query=category%3Areferences
 
 | Name                   | Description                 |
 |------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_000911) |
-| *data-stanza-gene-id   | Gene ID (e.g., slr1311)     |
+| *data-stanza-tax-id    | Taxonomy ID (e.g., 103690)  |
+| *data-stanza-gene-id   | Gene ID (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_references" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_references" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_references" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="/stanza/protein_references" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_references_stanza/stanza.rb
+++ b/protein_references_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class ProteinReferencesStanza < TogoStanza::Stanza::Base
-  property :references do |refseq_id, gene_id|
+  property :references do |tax_id, gene_id|
     query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       DEFINE sql:select-option "order"
       PREFIX up:   <http://purl.uniprot.org/core/>
@@ -9,7 +9,14 @@ class ProteinReferencesStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/uniprot>
       FROM <http://togogenome.org/graph/tgup>
       WHERE {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a up:Protein ;
                  up:citation ?citation .

--- a/protein_references_timeline_nano_stanza/help.md
+++ b/protein_references_timeline_nano_stanza/help.md
@@ -9,16 +9,16 @@ nanostanza for timeline view of protein reference
 
 | Name                   | Description                 |
 |------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_000911) |
-| *data-stanza-gene-id   | Gene ID (e.g., slr0473)     |
+| *data-stanza-tax-id    | Taxonomy ID (e.g., 103690)  |
+| *data-stanza-gene-id   | Gene ID (e.g., all1455)     |
 
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_references_timeline_nano" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr0473"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_references_timeline_nano" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_references_timeline_nano" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr0473"></div>
+<div data-stanza="/stanza/protein_references_timeline_nano" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_references_timeline_nano_stanza/stanza.rb
+++ b/protein_references_timeline_nano_stanza/stanza.rb
@@ -3,7 +3,7 @@ class ProteinReferencesTimelineNanoStanza < TogoStanza::Stanza::Base
     "Protein references timeline"
   end
 
-  property :references do |refseq_id, gene_id, step|
+  property :references do |tax_id, gene_id, step|
     refs = query('http://dev.togogenome.org/sparql-test', <<-SPARQL.strip_heredoc)
       PREFIX up: <http://purl.uniprot.org/core/>
 
@@ -12,7 +12,14 @@ class ProteinReferencesTimelineNanoStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/uniprot>
       FROM <http://togogenome.org/graph/tgup>
       WHERE {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a up:Protein ;
                  up:citation ?citation.

--- a/protein_sequence_annotation_stanza/help.md
+++ b/protein_sequence_annotation_stanza/help.md
@@ -9,15 +9,15 @@ See also: http://www.uniprot.org/manual/?query=category%3Asequence_annotation
 
 | Name                   | Description                 |
 |------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_000911) |
-| *data-stanza-gene-id   | Gene ID (e.g., slr1311)     |
+| *data-stanza-tax-id    | Taxonomy ID (e.g., 103690)  |
+| *data-stanza-gene-id   | Gene ID (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_sequence_annotation" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_sequence_annotation" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_sequence_annotation" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="/stanza/protein_sequence_annotation" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_sequence_annotation_stanza/stanza.rb
+++ b/protein_sequence_annotation_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class ProteinSequenceAnnotationStanza < TogoStanza::Stanza::Base
-  property :sequence_annotations do |refseq_id, gene_id|
+  property :sequence_annotations do |tax_id, gene_id|
     annotations = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       PREFIX up: <http://purl.uniprot.org/core/>
       PREFIX faldo: <http://biohackathon.org/resource/faldo#>
@@ -8,7 +8,14 @@ class ProteinSequenceAnnotationStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/uniprot>
       FROM <http://togogenome.org/graph/tgup>
       WHERE {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a up:Protein ;
                  up:annotation ?annotation .

--- a/protein_sequence_stanza/help.md
+++ b/protein_sequence_stanza/help.md
@@ -9,15 +9,15 @@ See also: http://www.uniprot.org/manual/?query=category%3Asequences
 
 | Name                   | Description                 |
 |------------------------|-----------------------------|
-| *data-stanza-refseq-id | Refseq ID (e.g., NC_000911) |
-| *data-stanza-gene-id   | Gene ID (e.g., slr1311)     |
+| *data-stanza-tax-id    | Taxonomy ID (e.g., 103690)  |
+| *data-stanza-gene-id   | Gene ID (e.g., all1455)     |
 
 ## Sample:
 
 ```html
-<div data-stanza="http://togogenome.org/stanza/protein_sequence" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="http://togogenome.org/stanza/protein_sequence" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>
 ```
 
 The above `<div>` will automatically embed the following Stanza in your HTML page.
 
-<div data-stanza="/stanza/protein_sequence" data-stanza-refseq-id="NC_000911" data-stanza-gene-id="slr1311"></div>
+<div data-stanza="/stanza/protein_sequence" data-stanza-tax-id="103690" data-stanza-gene-id="all1455"></div>

--- a/protein_sequence_stanza/stanza.rb
+++ b/protein_sequence_stanza/stanza.rb
@@ -1,5 +1,5 @@
 class ProteinSequenceStanza < TogoStanza::Stanza::Base
-  property :sequences do |refseq_id, gene_id|
+  property :sequences do |tax_id, gene_id|
     sequences = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       PREFIX up: <http://purl.uniprot.org/core/>
 
@@ -7,7 +7,14 @@ class ProteinSequenceStanza < TogoStanza::Stanza::Base
       FROM <http://togogenome.org/graph/uniprot>
       FROM <http://togogenome.org/graph/tgup>
       WHERE {
-        <http://togogenome.org/gene/#{refseq_id}:#{gene_id}> rdfs:seeAlso ?id_upid .
+        {
+          SELECT ?gene
+          {
+            <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene .
+          } ORDER BY ?gene LIMIT 1
+        }
+        <http://togogenome.org/gene/#{tax_id}:#{gene_id}> skos:exactMatch ?gene ;
+          rdfs:seeAlso ?id_upid .
         ?id_upid rdfs:seeAlso ?protein .
         ?protein a up:Protein ;
                  up:sequence ?isoform .


### PR DESCRIPTION
・geneレポートページのスタンザの引数をRefseqID+GeneID からTaxID+GeneIDに戻した。
・TaxID+GeneIDの指定ではRefSeqの一意なgeneのURI(ロケーション)を指せないため、複数あった場合にLIMIT 1で一つだけ選択するように変更した。
・Uniprotのデータスキーマが変更された事によりprotein_ontologies_stanzaのSPARQLを変更