### PR TITLE
[WIP] スタンザの `search` ブロックを削除

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -10,10 +10,6 @@ rescue
   log = $stdout
 end
 
-TogoStanza.configure do |config|
-  config.text_search_method = ENV['TEXT_SEARCH_METHOD'] || :regex # :regex, :contains, :bif_contains
-end
-
 use Rack::CommonLogger, log
 
 map '/stanza/assets' do

--- a/organism_names_stanza/stanza.rb
+++ b/organism_names_stanza/stanza.rb
@@ -1,23 +1,4 @@
 class OrganismNamesStanza < TogoStanza::Stanza::Base
-  search :organism_name_list do |query|
-    query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
-      PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy#>
-      PREFIX taxid: <http://identifiers.org/taxonomy/>
-
-      SELECT DISTINCT (REPLACE(STR(?taxonomy),"http://identifiers.org/taxonomy/","") AS ?tax_id)
-      FROM <http://togogenome.org/graph/taxonomy>
-      WHERE {
-        VALUES ?name_type {
-          tax:scientificName tax:synonym tax:preferredSynonym tax:acronym tax:preferredAcronym tax:anamorph tax:teleo
-          tax:misnomer tax:commonName tax:preferredCommonName tax:inPart tax:includes tax:equivalentName
-          tax:genbankSynonym tax:genbankCommonName tax:authority tax:misspelling
-        }
-        ?taxonomy ?name_type ?name .
-        #{text_search_filter(:name, query)}
-      }
-    SPARQL
-  end
-
   property :organism_name_list do |tax_id|
     results = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       PREFIX tax: <http://ddbj.nig.ac.jp/ontologies/taxonomy/>

--- a/organism_phenotype_stanza/stanza.rb
+++ b/organism_phenotype_stanza/stanza.rb
@@ -1,23 +1,4 @@
 class OrganismPhenotypeStanza < TogoStanza::Stanza::Base
-  search :phenotype_items do |query|
-    query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
-      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-      PREFIX up: <http://purl.uniprot.org/core/>
-      PREFIX idtax: <http://purl.uniprot.org/taxonomy/>
-
-      SELECT DISTINCT (REPLACE(STR(?tax_id),"http://identifiers.org/taxonomy/","") AS ?tax_id)
-      FROM <http://togogenome.org/graph/mpo>
-      FROM <http://togogenome.org/graph/gold>
-      WHERE {
-        ?tax_id ?p ?mpo_id .
-        ?mpo_id rdfs:label ?desc .
-        FILTER (lang(?desc) = "en")
-        #{text_search_filter(:desc, query)}
-        FILTER (regex(?tax_id, "identifiers.org"))
-      }
-    SPARQL
-  end
-
   property :phenotype_items do |tax_id|
     results = query("http://dev.togogenome.org/sparql-test", <<-SPARQL.strip_heredoc)
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>


### PR DESCRIPTION
全文検索エンジン(Solr)を利用する方針になったため、 `togostanza` 自体には全文検索の仕組みを持つ必要が無くなりました