### PR TITLE
display_end_pos が重複しておりました

### DIFF
--- a/organism_jbrowse_stanza/stanza.rb
+++ b/organism_jbrowse_stanza/stanza.rb
@@ -23,7 +23,7 @@ class OrganismJbrowseStanza < TogoStanza::Stanza::Base
     if results.length > 0 then
       display_start_pos = 1
       display_end_pos = [ results.first[:length].to_i, 200000 ].min
-      sequence_version = {:tax_id => tax_id, :ref => results.first[:version], :display_end_pos => display_start_pos, :display_end_pos => display_end_pos}
+      sequence_version = {:tax_id => tax_id, :ref => results.first[:version], :display_start_pos => display_start_pos, :display_end_pos => display_end_pos}
     else
       sequence_version = {:tax_id => nil}
     end

--- a/organism_jbrowse_stanza/stanza.rb
+++ b/organism_jbrowse_stanza/stanza.rb
@@ -23,9 +23,9 @@ class OrganismJbrowseStanza < TogoStanza::Stanza::Base
     if results.length > 0 then
       display_start_pos = 1
       display_end_pos = [ results.first[:length].to_i, 200000 ].min
-      sequence_version = {:tax_id => tax_id, :ref => results.first[:version], :display_start_pos => display_start_pos, :display_end_pos => display_end_pos}
+      sequence_version = {tax_id: tax_id, ref: results.first[:version], display_start_pos: display_start_pos, display_end_pos: display_end_pos}
     else
-      sequence_version = {:tax_id => nil}
+      sequence_version = {tax_id: nil}
     end
     sequence_version
   end


### PR DESCRIPTION
stanza の帰り値の Hash のキー(`display_end_pos`) が重複しており、ワーニングが出ていました。

変数 `display_start_pos` は `display_start_pos` キーじゃないかと予想して、修正してみましたがどうでしょう?  @okbp さん

以下は共に、organism/1140 の時です

before 
![dup_key](https://cloud.githubusercontent.com/assets/83493/10153885/bfeb6b32-669b-11e5-84b6-1117ce557438.png)

after
![single_key](https://cloud.githubusercontent.com/assets/83493/10153889/c5392c00-669b-11e5-8aa8-3a3ba44da7b3.png)