### PR TITLE
gemspec で metadata.json の内容を参照するようにした

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,7 +402,7 @@ GEM
       rack (>= 1.0)
     raindrops (0.13.0)
     rake (10.3.2)
-    rdf (1.1.16.1)
+    rdf (1.1.17.1)
       link_header (~> 0.0, >= 0.0.8)
     rltk (2.2.1)
       ffi (>= 1.0.0)
@@ -526,3 +526,6 @@ DEPENDENCIES
   togostanza
   unicorn
   variation_stanza!
+
+BUNDLED WITH
+   1.10.6

--- a/environment_attributes_stanza/environment_attributes_stanza.gemspec
+++ b/environment_attributes_stanza/environment_attributes_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_attributes_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Environmental attributes}
-  spec.description   = %q{Basic information of a environment ontology.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/environment_environmental_ontology_stanza/environment_environmental_ontology_stanza.gemspec
+++ b/environment_environmental_ontology_stanza/environment_environmental_ontology_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_environmental_ontology_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Environmental ontology}
-  spec.description   = %q{Visualization for the structure of MEO(Metagenome/Microbes Environment Ontology).}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/environment_geographical_map_stanza/environment_geographical_map_stanza.gemspec
+++ b/environment_geographical_map_stanza/environment_geographical_map_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_geographical_map_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Geographical map}
-  spec.description   = %q{Place where GOLD samples have sampled. }
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/environment_inhabitants_stanza/environment_inhabitants_stanza.gemspec
+++ b/environment_inhabitants_stanza/environment_inhabitants_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_inhabitants_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Inhabitants}
-  spec.description   = %q{List of samples and cultures which were sampled in specified environment.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/environment_inhabitants_statistics_nano_stanza/environment_inhabitants_statistics_nano_stanza.gemspec
+++ b/environment_inhabitants_statistics_nano_stanza/environment_inhabitants_statistics_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_inhabitants_statistics_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Environment Inhabitants Statistics Nano}
-  spec.description   = %q{NanoStanza: Display the number of organisms of a specified environment}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/environment_inhabitants_statistics_stanza/environment_inhabitants_statistics_stanza.gemspec
+++ b/environment_inhabitants_statistics_stanza/environment_inhabitants_statistics_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_inhabitants_statistics_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Inhabitants statistics}
-  spec.description   = %q{Number of samples and cultures which were sampled in specified environment.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/environment_organism_distribution_on_ph_nano_stanza/environment_organism_distribution_on_ph_nano_stanza.gemspec
+++ b/environment_organism_distribution_on_ph_nano_stanza/environment_organism_distribution_on_ph_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_organism_distribution_on_ph_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Environment Organism Distribution On Ph Nano}
-  spec.description   = %q{NanoStanza: Display the number of organisms along with growth pH for the specified environmental feature}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/environment_organism_distribution_on_temperature_nano_stanza/environment_organism_distribution_on_temperature_nano_stanza.gemspec
+++ b/environment_organism_distribution_on_temperature_nano_stanza/environment_organism_distribution_on_temperature_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_organism_distribution_on_temperature_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Environment Organism Distribution On Temperature Nano}
-  spec.description   = %q{NanoStanza: Display the number of Psychrophiles, Mesophiles and Thermophiles with the specified environmental feature }
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/environment_taxonomic_composition_stanza/environment_taxonomic_composition_stanza.gemspec
+++ b/environment_taxonomic_composition_stanza/environment_taxonomic_composition_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_taxonomic_composition_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Taxonomic composition}
-  spec.description   = %q{Visualization of the kind of organism which lives in specified environment.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/environment_top_level_symbolic_image_nano_stanza/environment_top_level_symbolic_image_nano_stanza.gemspec
+++ b/environment_top_level_symbolic_image_nano_stanza/environment_top_level_symbolic_image_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'environment_top_level_symbolic_image_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Environment Top Level Symbolic Image Nano}
-  spec.description   = %q{NanoStanza: Display an symbolic image for the MEO's toplevel category related to the given MEO ID.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/gene_attributes_stanza/gene_attributes_stanza.gemspec
+++ b/gene_attributes_stanza/gene_attributes_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'gene_attributes_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Gene Attributes}
-  spec.description   = %q{Basic information of the specified gene.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/gene_length_nano_stanza/gene_length_nano_stanza.gemspec
+++ b/gene_length_nano_stanza/gene_length_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'gene_length_nano_stanza'
   spec.version       = '0.0.1'
   spec.authors       = ['Toshiaki Katayama']
   spec.email         = ['ktym@dbcls.jp']
-  spec.summary       = %q{NanoStanza for showing gene length.}
-  spec.description   = %q{Total length of a gene region including exons and introns.}
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/geneset_entry_stanza/geneset_entry_stanza.gemspec
+++ b/geneset_entry_stanza/geneset_entry_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'geneset_entry_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Geneset Entry}
-  spec.description   = %q{TODO: Write a stanza description}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/geneset_entry_stanza/metadata.json
+++ b/geneset_entry_stanza/metadata.json
@@ -1,7 +1,7 @@
 {
   "@id": "http://togostanza.org/stanza/geneset_entry",
   "stanza:label": "Geneset Entry",
-  "stanza:definition": "TODO: Write a stanza description.",
+  "stanza:definition": "Geneset Entry",
   "stanza:parameter": [
     {
       "stanza:key": "uri",

--- a/geneset_stanza/geneset_stanza.gemspec
+++ b/geneset_stanza/geneset_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'geneset_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Geneset}
-  spec.description   = %q{a stanza for genesets}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/genome_cross_references_stanza/genome_cross_references_stanza.gemspec
+++ b/genome_cross_references_stanza/genome_cross_references_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'genome_cross_references_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Genome cross references}
-  spec.description   = %q{Table of cross references of a given genome.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/genome_genomic_context_stanza/genome_genomic_context_stanza.gemspec
+++ b/genome_genomic_context_stanza/genome_genomic_context_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'genome_genomic_context_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Genomic context}
-  spec.description   = %q{Schematic view of the structure and surroundings of a gene}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/genome_information_stanza/genome_information_stanza.gemspec
+++ b/genome_information_stanza/genome_information_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'genome_information_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Genome information}
-  spec.description   = %q{Genomic information of a taxonomy.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/genome_jbrowse_stanza/genome_jbrowse_stanza.gemspec
+++ b/genome_jbrowse_stanza/genome_jbrowse_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'genome_jbrowse_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Genomic context }
-  spec.description   = %q{Schematic view of the structure and surroundings of a gene}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/genome_plot_stanza/genome_plot_stanza.gemspec
+++ b/genome_plot_stanza/genome_plot_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'genome_plot_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Genomic plot}
-  spec.description   = %q{Scatter plot of genomic information.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/gmo_applied_spices_stanza/gmo_applied_spices_stanza.gemspec
+++ b/gmo_applied_spices_stanza/gmo_applied_spices_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'gmo_applied_spices_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Applied Spices}
-  spec.description   = %q{Applied Spices of medium.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/gmo_approximation_stanza/gmo_approximation_stanza.gemspec
+++ b/gmo_approximation_stanza/gmo_approximation_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'gmo_approximation_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Approximation}
-  spec.description   = %q{Medium to medium relevance ratio.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/gmo_genus_stanza/gmo_genus_stanza.gemspec
+++ b/gmo_genus_stanza/gmo_genus_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'gmo_genus_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Genus List (Medium-based)}
-  spec.description   = %q{Medium-based organism count list and group by genus.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lineage_information_stanza/lineage_information_stanza.gemspec
+++ b/lineage_information_stanza/lineage_information_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'lineage_information_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Taxonomic information}
-  spec.description   = %q{Lineage of the specified organism.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/medium_components_stanza/medium_components_stanza.gemspec
+++ b/medium_components_stanza/medium_components_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'medium_components_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Medium Components}
-  spec.description   = %q{Medium components and general information.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/microbial_phenotype_cell_shape_stanza/microbial_phenotype_cell_shape_stanza.gemspec
+++ b/microbial_phenotype_cell_shape_stanza/microbial_phenotype_cell_shape_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'microbial_phenotype_cell_shape_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Shape Information}
-  spec.description   = %q{phenotype's (with shaped, arrengement) visualizetion.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/microbial_phenotype_environment_composition_stanza/microbial_phenotype_environment_composition_stanza.gemspec
+++ b/microbial_phenotype_environment_composition_stanza/microbial_phenotype_environment_composition_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'microbial_phenotype_environment_composition_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Environment List (Phenotype-based)}
-  spec.description   = %q{Phenotype-based organism count list and group by environment.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/microbial_phenotype_genus_composition_stanza/microbial_phenotype_genus_composition_stanza.gemspec
+++ b/microbial_phenotype_genus_composition_stanza/microbial_phenotype_genus_composition_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'microbial_phenotype_genus_composition_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Genus List (Phenotype-based)}
-  spec.description   = %q{Phenotype-based organism count list and group by genus.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/microbial_phenotype_information_stanza/microbial_phenotype_information_stanza.gemspec
+++ b/microbial_phenotype_information_stanza/microbial_phenotype_information_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'microbial_phenotype_information_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism List}
-  spec.description   = %q{Organism list of having target phenotype. and groupping genus.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/nucleotide_sequence_stanza/nucleotide_sequence_stanza.gemspec
+++ b/nucleotide_sequence_stanza/nucleotide_sequence_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'nucleotide_sequence_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Nucleotide sequence}
-  spec.description   = %q{Nucleotide sequences of the specified gene ID.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_cross_references_stanza/organism_cross_references_stanza.gemspec
+++ b/organism_cross_references_stanza/organism_cross_references_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_cross_references_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism cross references}
-  spec.description   = %q{List of databases that references the specified organism.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_culture_collections_stanza/organism_culture_collections_stanza.gemspec
+++ b/organism_culture_collections_stanza/organism_culture_collections_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_culture_collections_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Culture collections}
-  spec.description   = %q{List of strains that is related to the specified taxonomy.These strains are related to taxonomy by NCBI taxonomy database or by sequence or by StrainInfo database or by strain name.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_gc_nano_stanza/organism_gc_nano_stanza.gemspec
+++ b/organism_gc_nano_stanza/organism_gc_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_gc_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism GC Nano}
-  spec.description   = %q{NanoStanza: Display GC percent of specified organism}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_gene_list_stanza/organism_gene_list_stanza.gemspec
+++ b/organism_gene_list_stanza/organism_gene_list_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_gene_list_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism Gene List}
-  spec.description   = %q{List of organism genes}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_gene_number_nano_stanza/organism_gene_number_nano_stanza.gemspec
+++ b/organism_gene_number_nano_stanza/organism_gene_number_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_gene_number_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism Gene Number Nano}
-  spec.description   = %q{NanoStanza: Display the number of gene, rrna and trna of a specified organism.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_genome_size_nano_stanza/organism_genome_size_nano_stanza.gemspec
+++ b/organism_genome_size_nano_stanza/organism_genome_size_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_genome_size_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism Genome Size Nano}
-  spec.description   = %q{NanoStanza: Display the size of genome of a specified organism.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_habitat_stanza/organism_habitat_stanza.gemspec
+++ b/organism_habitat_stanza/organism_habitat_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_habitat_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism habitat}
-  spec.description   = %q{Link list of organism habitat}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_jbrowse_stanza/organism_jbrowse_stanza.gemspec
+++ b/organism_jbrowse_stanza/organism_jbrowse_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_jbrowse_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Genomic context }
-  spec.description   = %q{Schematic view of the genome of the specified organism}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_medium_information_stanza/organism_medium_information_stanza.gemspec
+++ b/organism_medium_information_stanza/organism_medium_information_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_medium_information_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Medium information}
-  spec.description   = %q{Medium information of the specified organism.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_microbial_cell_shape_nano_stanza/organism_microbial_cell_shape_nano_stanza.gemspec
+++ b/organism_microbial_cell_shape_nano_stanza/organism_microbial_cell_shape_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_microbial_cell_shape_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism Microbial Cell Shape Nano}
-  spec.description   = %q{NanoStanza: Display an illustlation of the cell shape or arrangement of the specified organism.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_names_stanza/organism_names_stanza.gemspec
+++ b/organism_names_stanza/organism_names_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_names_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism names}
-  spec.description   = %q{List of organism names and synonyms.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_pathogen_information_stanza/organism_pathogen_information_stanza.gemspec
+++ b/organism_pathogen_information_stanza/organism_pathogen_information_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_pathogen_information_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Pathogen information}
-  spec.description   = %q{List of organisms and associated pathogen which have linage of the specified taxonomy.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_ph_nano_stanza/organism_ph_nano_stanza.gemspec
+++ b/organism_ph_nano_stanza/organism_ph_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_ph_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism pH Nano}
-  spec.description   = %q{NanoStanza: Display growth pH of the specified organism}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_phenotype_stanza/organism_phenotype_stanza.gemspec
+++ b/organism_phenotype_stanza/organism_phenotype_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_phenotype_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Phenotype information}
-  spec.description   = %q{Phenotype information of specified organism.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/organism_related_disease_nano_stanza/organism_related_disease_nano_stanza.gemspec
+++ b/organism_related_disease_nano_stanza/organism_related_disease_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'organism_related_disease_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Organism Related Disease Nano}
-  spec.description   = %q{NanoStanza: Show a pathogen symbol}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_3d_structure_nano_stanza/protein_3d_structure_nano_stanza.gemspec
+++ b/protein_3d_structure_nano_stanza/protein_3d_structure_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_3d_structure_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein 3D Structure Nano}
-  spec.description   = %q{NanoStanza: Display an schematic mage of protein 3D structure of specifined genes}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_attributes_stanza/protein_attributes_stanza.gemspec
+++ b/protein_attributes_stanza/protein_attributes_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_attributes_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein attributes}
-  spec.description   = %q{See also: http://www.uniprot.org/manual/?query=category%3Aprotein_attributes}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_cross_references_stanza/protein_cross_references_stanza.gemspec
+++ b/protein_cross_references_stanza/protein_cross_references_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_cross_references_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein cross references}
-  spec.description   = %q{See also: http://www.uniprot.org/manual/?query=category%3Across_references}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_ec_number_nano_stanza/protein_ec_number_nano_stanza.gemspec
+++ b/protein_ec_number_nano_stanza/protein_ec_number_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_ec_number_nano_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein EC Number Nano}
-  spec.description   = %q{NanoStanza: Display an EC number of an enzyme coded by a specified gene}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_general_annotation_stanza/protein_general_annotation_stanza.gemspec
+++ b/protein_general_annotation_stanza/protein_general_annotation_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_general_annotation_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein general annotation}
-  spec.description   = %q{See also: http://www.uniprot.org/manual/?query=category%3Ageneral_annotation}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_names_stanza/protein_names_stanza.gemspec
+++ b/protein_names_stanza/protein_names_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_names_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein names}
-  spec.description   = %q{See also: http://www.uniprot.org/manual/?query=category%3Anames_origin}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_ontologies_stanza/protein_ontologies_stanza.gemspec
+++ b/protein_ontologies_stanza/protein_ontologies_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_ontologies_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein ontologies}
-  spec.description   = %q{See also: http://www.uniprot.org/manual/?query=category%3Aontologies}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_orthologs_stanza/protein_orthologs_stanza.gemspec
+++ b/protein_orthologs_stanza/protein_orthologs_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_orthologs_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein Orthologs}
-  spec.description   = %q{Show members of ortholog group}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_pfam_plot_stanza/protein_pfam_plot_stanza.gemspec
+++ b/protein_pfam_plot_stanza/protein_pfam_plot_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_pfam_plot_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Pfam plot}
-  spec.description   = %q{Scatter plot of pfam corresponding with genes.}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_references_stanza/protein_references_stanza.gemspec
+++ b/protein_references_stanza/protein_references_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_references_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein references}
-  spec.description   = %q{See also: http://www.uniprot.org/manual/?query=category%3Areferences}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_references_timeline_nano_stanza/protein_references_timeline_nano_stanza.gemspec
+++ b/protein_references_timeline_nano_stanza/protein_references_timeline_nano_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_references_timeline_nano_stanza'
   spec.version       = '0.0.1'
   spec.authors       = ['Takatomo Fujisawa']
   spec.email         = ['fujisawa.takatomo@gmail.com']
-  spec.summary       = %q{nanostanza for timeline view of protein references}
-  spec.description   = %q{}
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_sequence_annotation_stanza/protein_sequence_annotation_stanza.gemspec
+++ b/protein_sequence_annotation_stanza/protein_sequence_annotation_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_sequence_annotation_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein sequence annotation}
-  spec.description   = %q{See also: http://www.uniprot.org/manual/?query=category%3Asequence_annotation}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/protein_sequence_stanza/protein_sequence_stanza.gemspec
+++ b/protein_sequence_stanza/protein_sequence_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'protein_sequence_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Protein sequence}
-  spec.description   = %q{See also: http://www.uniprot.org/manual/?query=category%3Asequences}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/taxonomy_ortholog_profile_stanza/taxonomy_ortholog_profile_stanza.gemspec
+++ b/taxonomy_ortholog_profile_stanza/taxonomy_ortholog_profile_stanza.gemspec
@@ -1,15 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'taxonomy_ortholog_profile_stanza'
   spec.version       = '0.0.1'
-  spec.authors       = ['TODO: Write your name']
-  spec.email         = ['']
-  spec.summary       = %q{Taxonomy Ortholog Profile}
-  spec.description   = %q{}
+  spec.authors       = Array(metadata["stanza:author"])
+  spec.email         = Array(metadata["stanza:address"])
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/variation_stanza/variation_stanza.gemspec
+++ b/variation_stanza/variation_stanza.gemspec
@@ -2,15 +2,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+require 'json'
+metadata = open('./metadata.json') do |io|
+  JSON.load(io)
+end
+
 Gem::Specification.new do |spec|
   spec.name          = 'variation_stanza'
   spec.version       = '0.0.1'
   spec.authors       = ['Keita Urashima']
   spec.email         = ['ursm@ursm.jp']
-  spec.summary       = %q{Variation}
-  spec.description   = %q{a stanza for variations}
+  spec.summary       = metadata["stanza:label"]
+  spec.description   = metadata["stanza:definition"]
   spec.homepage      = ''
-  spec.license       = 'MIT'
+  spec.license       = metadata["stanza:license"]
 
   spec.files         = Dir.glob('**/*')
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
スタンザ開発者が、metadata.json と xxxx.gemspec の両方を編集するのは二度手間となるため、
metadata.json のみを変更すれば良くなるように、metadata.json の内容を gemspec で参照するようにした