### PR TITLE
Update query for wikidata gene

### DIFF
--- a/gene_wikidata_nano_stanza/stanza.rb
+++ b/gene_wikidata_nano_stanza/stanza.rb
@@ -9,12 +9,21 @@ class GeneWikidataNanoStanza < TogoStanza::Stanza::Base
       PREFIX wdt: <http://www.wikidata.org/prop/direct/>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-      SELECT DISTINCT ?species ?taxid ?gene ?locustag
-      WHERE {
+      SELECT DISTINCT * #?species ?taxid ?gene ?locustag
+      WHERE
+      {
         VALUES ?taxid { "#{tax_id}" }
-        VALUES ?lucustag { "#{gene_id}" }
-        ?gene wdt:P703 ?species . # P703 Found in taxon
-        OPTIONAL { ?gene wdt:P2393 ?locustag }
+        VALUES ?gene_id { "#{gene_id}"@en "#{gene_id}" }
+
+        ?gene rdfs:label | wdt:P2393 ?gene_id .
+        {
+          ?gene wdt:P703 ?species . # P703 Found in taxon
+        }
+        UNION
+        {
+           ?gene wdt:P703 ?species2 . # P703 Found in taxon
+           ?species2 wdt:P460 ?species . # Same as
+        }
         ?species wdt:P685 ?taxid .
       }
     SPARQL


### PR DESCRIPTION
真核と原核の両方に対応するSPARQLに修正